### PR TITLE
Add rebate offer type to the React SDK

### DIFF
--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -59,7 +59,7 @@ const SCENARIOS: { id: Scenario; label: string; description: string }[] = [
   {
     id: 'all-offers',
     label: 'All Built-in Offer Types',
-    description: 'discount, pause, plan_change, trial_extension, contact, redirect — one reason each.',
+    description: 'discount, pause, plan_change, trial_extension, contact, redirect, rebate — one reason each.',
   },
   {
     id: 'standalone-offer',
@@ -193,6 +193,19 @@ const allOffersSteps: Step[] = [
         id: 'redirect',
         label: 'Learn more (→ redirect)',
         offer: { type: 'redirect', url: 'https://example.com/docs', label: 'See docs' },
+      },
+      {
+        id: 'rebate',
+        label: 'Within the guarantee window (→ rebate)',
+        offer: {
+          type: 'rebate',
+          amountMinor: 500,
+          currency: 'USD',
+          amountPaidMinor: 10890,
+          netAfterRebateMinor: 10390,
+          paymentMethodBrand: 'visa',
+          paymentMethodLast4: '4242',
+        },
       },
       { id: 'none', label: 'No reason (no offer)' },
     ],

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect breaking changes in minor versions while we're pre-1.0.
 
+## 0.4.0 — 2026-05-29
+
+### Added
+
+- **Rebate offer type.** A `rebate` is a partial refund of the customer's most recent paid invoice while their subscription stays active — aimed at money-back-guarantee windows, where a customer who would cancel to get their money back can take a partial refund and stay instead.
+  - The `'rebate'` offer type joins the config union — the local shape plus the fields resolved in token mode (`amountMinor`, `currency`, `amountPaidMinor`, `netAfterRebateMinor`) — wired through the state machine, the config transform, and the offer-type map.
+  - `DefaultRebateOffer` renders the offer as an itemized invoice: the period charge, the rebate being credited, and what's still due, with the rebate line accented. Overridable via `components.RebateOffer`.
+  - `handleRebate` / `onRebate` callbacks, matching the other offer types. In connected mode the SDK runs the rebate server-side; defining `handleRebate` overrides that to run the refund through your own billing.
+  - The accepted rebate amount is recorded on the session.
+
+### Changed
+
+- Offer panels now share one surface. The discount and trial-extension panels use `colorSurfaceMuted` (the neutral callout surface) instead of `colorPrimarySoft` (the indigo tint), so every offer panel reads consistently and `colorPrimarySoft` is reserved for selected-state highlights as documented. Override the relevant `--ck-*` properties to restore the previous tint.
+
 ## 0.3.0 — 2026-05-19
 
 ### Added

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/react",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Production-ready cancel flow for React. Drop-in component, headless hook, or full customization. Works standalone or with Churnkey for AI-powered retention.",
   "license": "MIT",
   "repository": {

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -10,6 +10,7 @@ export { DefaultContactOffer } from './steps/offer/default-contact-offer'
 export { DefaultDiscountOffer } from './steps/offer/default-discount-offer'
 export { DefaultPauseOffer } from './steps/offer/default-pause-offer'
 export { DefaultPlanChangeOffer } from './steps/offer/default-plan-change-offer'
+export { DefaultRebateOffer } from './steps/offer/default-rebate-offer'
 export { DefaultRedirectOffer } from './steps/offer/default-redirect-offer'
 export { DefaultTrialExtensionOffer } from './steps/offer/default-trial-extension-offer'
 // Structural

--- a/packages/react/src/components/steps/default-offer.tsx
+++ b/packages/react/src/components/steps/default-offer.tsx
@@ -4,6 +4,7 @@ import { DefaultContactOffer } from './offer/default-contact-offer'
 import { DefaultDiscountOffer } from './offer/default-discount-offer'
 import { DefaultPauseOffer } from './offer/default-pause-offer'
 import { DefaultPlanChangeOffer } from './offer/default-plan-change-offer'
+import { DefaultRebateOffer } from './offer/default-rebate-offer'
 import { DefaultRedirectOffer } from './offer/default-redirect-offer'
 import { DefaultTrialExtensionOffer } from './offer/default-trial-extension-offer'
 
@@ -43,6 +44,8 @@ function pickOfferComponent(
       return components?.ContactOffer ?? DefaultContactOffer
     case 'redirect':
       return components?.RedirectOffer ?? DefaultRedirectOffer
+    case 'rebate':
+      return components?.RebateOffer ?? DefaultRebateOffer
     default:
       return null
   }

--- a/packages/react/src/components/steps/offer/default-rebate-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-rebate-offer.tsx
@@ -8,8 +8,6 @@ type RebateDecision = OfferDecision & {
   currency?: string
   amountPaidMinor?: number
   netAfterRebateMinor?: number
-  paymentMethodBrand?: string
-  paymentMethodLast4?: string
 }
 
 export function DefaultRebateOffer({
@@ -26,7 +24,6 @@ export function DefaultRebateOffer({
   const body = description ?? offer.copy.body
   const currency = o.currency ?? 'usd'
   const amount = o.amountMinor ?? 0
-  const card = [o.paymentMethodBrand, o.paymentMethodLast4].filter(Boolean).join(' •••• ')
 
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
@@ -34,20 +31,23 @@ export function DefaultRebateOffer({
       {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
+        {/* Itemized like an invoice: the period charge, the rebate we credit
+            (the accented line), and what's still due. Paid and net are
+            server-resolved in token mode, so each renders only when present. */}
         <div className="ck-offer-rebate">
           {o.amountPaidMinor != null && (
             <div className="ck-offer-rebate-row">
-              <span>You paid this period</span>
+              <span>Subscription · this period</span>
               <span>{formatPriceFromMinor(o.amountPaidMinor, currency)}</span>
             </div>
           )}
-          <div className="ck-offer-rebate-row">
-            <span>{card ? `Refund to your ${card}` : 'Refund to your card'}</span>
-            <span className="ck-offer-rebate-refund">−{formatPriceFromMinor(amount, currency)}</span>
+          <div className="ck-offer-rebate-row ck-offer-rebate-credit">
+            <span>Cancellation rebate</span>
+            <span>−{formatPriceFromMinor(amount, currency)}</span>
           </div>
           {o.netAfterRebateMinor != null && (
             <div className="ck-offer-rebate-row ck-offer-rebate-total">
-              <span>Your net for the period</span>
+              <span>Due for this period</span>
               <span>{formatPriceFromMinor(o.netAfterRebateMinor, currency)}</span>
             </div>
           )}

--- a/packages/react/src/components/steps/offer/default-rebate-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-rebate-offer.tsx
@@ -1,0 +1,70 @@
+import { formatPriceFromMinor } from '../../../core/format'
+import type { OfferDecision, OfferStepProps } from '../../../core/types'
+import { cn } from '../../../core/utils'
+import { RichText } from '../../rich-text'
+
+type RebateDecision = OfferDecision & {
+  amountMinor?: number
+  currency?: string
+  amountPaidMinor?: number
+  netAfterRebateMinor?: number
+  paymentMethodBrand?: string
+  paymentMethodLast4?: string
+}
+
+export function DefaultRebateOffer({
+  title,
+  description,
+  offer,
+  onAccept,
+  onDecline,
+  isProcessing,
+  classNames,
+}: OfferStepProps) {
+  const o = offer as RebateDecision
+  const headline = title ?? offer.copy.headline
+  const body = description ?? offer.copy.body
+  const currency = o.currency ?? 'usd'
+  const amount = o.amountMinor ?? 0
+  const card = [o.paymentMethodBrand, o.paymentMethodLast4].filter(Boolean).join(' •••• ')
+
+  return (
+    <div className={cn('ck-step ck-step-offer', classNames?.root)}>
+      {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
+      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+
+      <div className={cn('ck-offer-card', classNames?.card)}>
+        <div className="ck-offer-rebate">
+          {o.amountPaidMinor != null && (
+            <div className="ck-offer-rebate-row">
+              <span>You paid this period</span>
+              <span>{formatPriceFromMinor(o.amountPaidMinor, currency)}</span>
+            </div>
+          )}
+          <div className="ck-offer-rebate-row">
+            <span>{card ? `Refund to your ${card}` : 'Refund to your card'}</span>
+            <span className="ck-offer-rebate-refund">−{formatPriceFromMinor(amount, currency)}</span>
+          </div>
+          {o.netAfterRebateMinor != null && (
+            <div className="ck-offer-rebate-row ck-offer-rebate-total">
+              <span>Your net for the period</span>
+              <span>{formatPriceFromMinor(o.netAfterRebateMinor, currency)}</span>
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          className={cn('ck-button ck-button-primary', classNames?.acceptButton)}
+          onClick={() => onAccept()}
+          disabled={isProcessing}
+        >
+          {isProcessing ? 'Processing...' : offer.copy.cta}
+        </button>
+        <button type="button" className={cn('ck-button-link', classNames?.declineButton)} onClick={onDecline}>
+          {offer.copy.declineCta}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/core/api-types.ts
+++ b/packages/react/src/core/api-types.ts
@@ -65,6 +65,7 @@ export type SdkOffer =
   | SdkTrialExtensionOffer
   | SdkRedirectOffer
   | SdkContactOffer
+  | SdkRebateOffer
 
 interface SdkOfferBase {
   /** Per-offer guid — used for analytics joins between presented and accepted offers. */
@@ -109,6 +110,19 @@ export interface SdkContactOffer extends SdkOfferBase {
   type: 'contact'
   url?: string
   label?: string
+}
+
+export interface SdkRebateOffer extends SdkOfferBase {
+  type: 'rebate'
+  /** Cash refunded to the card, smallest currency unit. */
+  amountMinor: number
+  currency: string
+  /** Gross amount paid on the target invoice — the "you paid" row. */
+  amountPaidMinor: number
+  /** amountPaidMinor − amountMinor — the "your net" row. */
+  netAfterRebateMinor: number
+  paymentMethodBrand?: string
+  paymentMethodLast4?: string
 }
 
 export interface SdkOfferCopy {

--- a/packages/react/src/core/api.ts
+++ b/packages/react/src/core/api.ts
@@ -7,7 +7,15 @@ const DEFAULT_BASE_URL = 'https://api.churnkey.co/v1'
 // Wire enums accepted by the API. Literal unions so payload builders fail
 // at compile time if they emit a value outside the accepted set.
 export type ApiStepType = 'OFFER' | 'SURVEY' | 'CONFIRM' | 'FREEFORM' | 'CUSTOM'
-export type ApiOfferType = 'DISCOUNT' | 'PAUSE' | 'PLAN_CHANGE' | 'TRIAL_EXTENSION' | 'CONTACT' | 'REDIRECT' | 'CUSTOM'
+export type ApiOfferType =
+  | 'DISCOUNT'
+  | 'PAUSE'
+  | 'PLAN_CHANGE'
+  | 'TRIAL_EXTENSION'
+  | 'CONTACT'
+  | 'REDIRECT'
+  | 'REBATE'
+  | 'CUSTOM'
 export type ApiPauseInterval = 'MONTH' | 'WEEK'
 export type ApiCouponType = 'PERCENT' | 'AMOUNT'
 export type ApiBillingInterval = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'
@@ -54,6 +62,7 @@ export interface AcceptedOfferPayload {
   newPlanPrice?: number
   trialExtensionDays?: number
   redirectUrl?: string
+  rebateAmount?: number
 }
 
 export interface SessionCustomer {
@@ -172,6 +181,10 @@ export class ChurnkeyApi {
 
   async extendTrial(days: number, blueprintId?: string): Promise<void> {
     await this.request(this.orgUrl('cancel-flow/actions/extend-trial'), { days, blueprintId })
+  }
+
+  async applyRebate(blueprintId?: string, offerGuid?: string): Promise<void> {
+    await this.request(this.orgUrl('cancel-flow/actions/rebate'), { blueprintId, offerGuid })
   }
 
   async createSession(payload: SessionPayload): Promise<void> {

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -61,6 +61,7 @@ export type {
   PlanOption,
   ReasonButtonProps,
   ReasonConfig,
+  RebateOffer,
   RedirectOffer,
   Step,
   StructuralClassNames,

--- a/packages/react/src/core/machine.ts
+++ b/packages/react/src/core/machine.ts
@@ -40,6 +40,8 @@ function handlerFor(offerType: string, cb: FlowCallbacks): OfferCallback | undef
       return cb.handlePlanChange
     case 'trial_extension':
       return cb.handleTrialExtension
+    case 'rebate':
+      return cb.handleRebate
     default:
       return undefined
   }
@@ -55,6 +57,8 @@ function listenerFor(offerType: string, cb: FlowCallbacks): OfferCallback | unde
       return cb.onPlanChange
     case 'trial_extension':
       return cb.onTrialExtension
+    case 'rebate':
+      return cb.onRebate
     default:
       return undefined
   }
@@ -93,6 +97,7 @@ const OFFER_TYPE_API_MAP: Record<BuiltInOfferConfig['type'], Exclude<ApiOfferTyp
   trial_extension: 'TRIAL_EXTENSION',
   contact: 'CONTACT',
   redirect: 'REDIRECT',
+  rebate: 'REBATE',
 }
 
 // 'success' isn't a stepsViewed entry — the session's outcome/canceled/
@@ -186,6 +191,8 @@ function toAcceptedOfferPayload(rec: OfferDecision, result?: Record<string, unkn
       return { ...base, trialExtensionDays: o.days }
     case 'redirect':
       return { ...base, redirectUrl: o.url }
+    case 'rebate':
+      return { ...base, rebateAmount: o.amountMinor }
     default:
       return base
   }
@@ -361,7 +368,7 @@ export class CancelFlowMachine {
       if (handler) {
         await handler(acceptedOffer, customer)
       } else if (this.isTokenMode()) {
-        await this.executeTokenAction(acceptedOffer)
+        await this.executeTokenAction(acceptedOffer, offer.decisionId)
       }
 
       // Listeners fire after the action succeeded, regardless of who ran it.
@@ -548,7 +555,7 @@ export class CancelFlowMachine {
     }
   }
 
-  private async executeTokenAction(offer: AcceptedOffer): Promise<void> {
+  private async executeTokenAction(offer: AcceptedOffer, decisionId?: string): Promise<void> {
     if (!this.apiClient) return
 
     // Only built-in offer types have a server action; custom types route
@@ -568,6 +575,9 @@ export class CancelFlowMachine {
         break
       case 'trial_extension':
         await this.apiClient.extendTrial(o.days, this.blueprintId ?? undefined)
+        break
+      case 'rebate':
+        await this.apiClient.applyRebate(this.blueprintId ?? undefined, decisionId)
         break
     }
   }

--- a/packages/react/src/core/transform.ts
+++ b/packages/react/src/core/transform.ts
@@ -117,6 +117,16 @@ function transformOfferConfig(o: SdkOffer): OfferConfig {
         url: o.url,
         label: o.label,
       }
+    case 'rebate':
+      return {
+        type: 'rebate',
+        amountMinor: o.amountMinor,
+        currency: o.currency,
+        amountPaidMinor: o.amountPaidMinor,
+        netAfterRebateMinor: o.netAfterRebateMinor,
+        paymentMethodBrand: o.paymentMethodBrand,
+        paymentMethodLast4: o.paymentMethodLast4,
+      }
   }
 }
 
@@ -168,6 +178,13 @@ export function defaultOfferCopy(offer: OfferConfig): OfferCopy {
         headline: 'Before you go...',
         body: 'Check this out — it might change your mind.',
         cta: o.label,
+        declineCta: 'No thanks',
+      }
+    case 'rebate':
+      return {
+        headline: 'Get money back',
+        body: "Stay subscribed and we'll refund part of your most recent payment.",
+        cta: 'Accept refund',
         declineCta: 'No thanks',
       }
     default:

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -161,6 +161,19 @@ export interface RedirectOffer {
   label: string
 }
 
+export interface RebateOffer {
+  type: 'rebate'
+  /** Cash refunded to the card, smallest currency unit. */
+  amountMinor: number
+  currency: string
+  /** Gross paid on the target invoice. Server-resolved in token mode. */
+  amountPaidMinor?: number
+  /** amountPaidMinor − amountMinor. Server-resolved in token mode. */
+  netAfterRebateMinor?: number
+  paymentMethodBrand?: string
+  paymentMethodLast4?: string
+}
+
 export interface CustomOfferConfig {
   type: string
   data?: Record<string, unknown>
@@ -173,6 +186,7 @@ export type BuiltInOfferConfig =
   | TrialExtensionOffer
   | ContactOffer
   | RedirectOffer
+  | RebateOffer
 export type OfferConfig = BuiltInOfferConfig | CustomOfferConfig
 
 export type OfferDecision = OfferConfig & { copy: OfferCopy; decisionId?: string }
@@ -480,6 +494,7 @@ export interface ComponentOverrides {
   TrialExtensionOffer?: (props: OfferStepProps) => ReactElement
   ContactOffer?: (props: OfferStepProps) => ReactElement
   RedirectOffer?: (props: OfferStepProps) => ReactElement
+  RebateOffer?: (props: OfferStepProps) => ReactElement
 }
 
 export type CustomComponents = Record<string, ComponentType<CustomStepProps> | ComponentType<CustomOfferProps>>
@@ -648,6 +663,7 @@ export interface FlowCallbacks {
   handlePause?: OfferCallback
   handlePlanChange?: OfferCallback
   handleTrialExtension?: OfferCallback
+  handleRebate?: OfferCallback
   handleCancel?: CancelCallback
 
   onAccept?: OfferCallback
@@ -655,6 +671,7 @@ export interface FlowCallbacks {
   onPause?: OfferCallback
   onPlanChange?: OfferCallback
   onTrialExtension?: OfferCallback
+  onRebate?: OfferCallback
   onCancel?: CancelCallback
   onClose?: () => void
   onStepChange?: (step: string, prevStep: string) => void

--- a/packages/react/src/core/utils.ts
+++ b/packages/react/src/core/utils.ts
@@ -9,6 +9,7 @@ export const BUILT_IN_OFFER_TYPES: readonly string[] = [
   'plan_change',
   'contact',
   'redirect',
+  'rebate',
 ]
 
 export function cn(...classes: (string | undefined | null | false)[]): string {

--- a/packages/react/src/styles/cancel-flow.css
+++ b/packages/react/src/styles/cancel-flow.css
@@ -457,6 +457,39 @@
   color: var(--ck-color-text);
 }
 
+/* Rebate: an itemized amount card — what you paid, the refund, the net. */
+.ck-cancel-flow .ck-offer-rebate {
+  background: var(--ck-color-surface-muted);
+  border-radius: var(--ck-radius-lg);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.ck-cancel-flow .ck-offer-rebate-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--ck-color-text-muted);
+  margin-bottom: 8px;
+}
+
+.ck-cancel-flow .ck-offer-rebate-refund {
+  color: var(--ck-color-primary);
+  font-weight: 600;
+}
+
+.ck-cancel-flow .ck-offer-rebate-total {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--ck-color-border);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ck-color-text);
+  margin-bottom: 0;
+}
+
 /* Pause: resume date is the typographic anchor, month chips below. */
 .ck-cancel-flow .ck-pause-card {
   padding: 32px 24px 22px;

--- a/packages/react/src/styles/cancel-flow.css
+++ b/packages/react/src/styles/cancel-flow.css
@@ -431,10 +431,17 @@
   margin-bottom: 20px;
 }
 
-/* Discount: centered phrase in a soft tinted panel. */
-.ck-cancel-flow .ck-offer-discount {
-  background: var(--ck-color-primary-soft);
+/* Offer panels are soft callouts (colorSurfaceMuted), not selected-state
+   highlights (colorPrimarySoft). Shared so the offer types stay consistent. */
+.ck-cancel-flow .ck-offer-discount,
+.ck-cancel-flow .ck-pause-card,
+.ck-cancel-flow .ck-trial-block {
+  background: var(--ck-color-surface-muted);
   border-radius: var(--ck-radius-lg);
+}
+
+/* Discount: centered phrase. */
+.ck-cancel-flow .ck-offer-discount {
   padding: 24px 20px;
   text-align: center;
 }
@@ -457,12 +464,12 @@
   color: var(--ck-color-text);
 }
 
-/* Rebate: an itemized amount card — what you paid, the refund, the net. */
+/* Rebate: an itemized invoice for the period — the charge, the rebate we
+   credit (accented), and what's still due. Lines sit on the surface rather
+   than in a filled panel. */
 .ck-cancel-flow .ck-offer-rebate {
-  background: var(--ck-color-surface-muted);
-  border-radius: var(--ck-radius-lg);
-  padding: 20px;
-  margin-bottom: 16px;
+  margin: 4px 0 26px;
+  font-variant-numeric: tabular-nums;
 }
 
 .ck-cancel-flow .ck-offer-rebate-row {
@@ -470,31 +477,30 @@
   justify-content: space-between;
   align-items: baseline;
   gap: 12px;
-  font-size: 14px;
+  padding: 7px 0;
+  font-size: 13px;
   color: var(--ck-color-text-muted);
-  margin-bottom: 8px;
 }
 
-.ck-cancel-flow .ck-offer-rebate-refund {
-  color: var(--ck-color-primary);
+/* The rebate line — the figure we want the eye to land on. */
+.ck-cancel-flow .ck-offer-rebate-credit {
+  font-size: 14px;
   font-weight: 600;
+  color: var(--ck-color-primary);
 }
 
 .ck-cancel-flow .ck-offer-rebate-total {
-  margin-top: 12px;
-  padding-top: 12px;
+  margin-top: 6px;
+  padding-top: 14px;
   border-top: 1px solid var(--ck-color-border);
   font-size: 15px;
   font-weight: 600;
   color: var(--ck-color-text);
-  margin-bottom: 0;
 }
 
 /* Pause: resume date is the typographic anchor, month chips below. */
 .ck-cancel-flow .ck-pause-card {
   padding: 32px 24px 22px;
-  background: var(--ck-color-surface-muted);
-  border-radius: var(--ck-radius-lg);
   text-align: center;
   margin: 8px 0 20px;
 }
@@ -548,14 +554,12 @@
   border-color: var(--ck-color-primary);
 }
 
-/* Trial extension: day count badge + new end date in accent-soft container. */
+/* Trial extension: day count badge + new end date. */
 .ck-cancel-flow .ck-trial-block {
   display: flex;
   align-items: center;
   gap: 16px;
   padding: 20px;
-  background: var(--ck-color-primary-soft);
-  border-radius: var(--ck-radius-lg);
 }
 
 .ck-cancel-flow .ck-trial-badge {

--- a/packages/react/tests/core/api.test.ts
+++ b/packages/react/tests/core/api.test.ts
@@ -4,8 +4,6 @@ import type { SessionCredentials } from '../../src/core/token'
 
 // Pins the action path and body shape for every cancel-flow action so a
 // server/SDK drift produces a test failure rather than a runtime 404.
-// Backend alias routes live in churnkey-api/src/api/org/index.js alongside
-// the legacy /stripe/* paths the hosted embed still uses.
 
 const creds: SessionCredentials = {
   appId: 'app_test',

--- a/packages/react/tests/core/machine.test.ts
+++ b/packages/react/tests/core/machine.test.ts
@@ -354,6 +354,60 @@ describe('CancelFlowMachine', () => {
     })
   })
 
+  describe('rebate offer', () => {
+    const rebateSteps = {
+      steps: [
+        {
+          type: 'survey' as const,
+          reasons: [
+            {
+              id: 'price',
+              label: 'Too expensive',
+              offer: { type: 'rebate' as const, amountMinor: 1000, currency: 'usd' },
+            },
+          ],
+        },
+        { type: 'confirm' as const },
+      ],
+    }
+
+    it('routes the accepted offer to handleRebate in local mode', async () => {
+      const handleRebate = vi.fn()
+      const machine = new CancelFlowMachine({ ...rebateSteps, handleRebate })
+      machine.selectReason('price')
+      machine.next()
+      await machine.accept()
+
+      expect(handleRebate).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'rebate', amountMinor: 1000, currency: 'usd', reasonId: 'price' }),
+        null,
+      )
+      expect(machine.getSnapshot().step).toBe('success')
+    })
+
+    it('token mode calls applyRebate with the blueprint id', async () => {
+      const mockApi = {
+        applyRebate: vi.fn(async (_blueprintId?: string, _offerGuid?: string) => {}),
+        cancelSubscription: vi.fn(async () => {}),
+        createSession: vi.fn(async () => {}),
+      }
+      const machine = new CancelFlowMachine({ ...rebateSteps, session: 'ck_placeholder' })
+      machine.initializeFromConfig(sdkConfig({ blueprintId: 'bp_1' }), mockApi as any, {
+        appId: 'a',
+        customerId: 'c',
+        authHash: 'h',
+        mode: 'live' as const,
+        issuedAt: 0,
+      })
+      machine.selectReason('price')
+      machine.next()
+      await machine.accept()
+
+      expect(mockApi.applyRebate).toHaveBeenCalledOnce()
+      expect(mockApi.applyRebate.mock.calls[0][0]).toBe('bp_1')
+    })
+  })
+
   describe('decline', () => {
     it('moves to the declared next step after the offer', () => {
       const machine = new CancelFlowMachine(baseConfig)

--- a/packages/react/tests/core/transform.test.ts
+++ b/packages/react/tests/core/transform.test.ts
@@ -87,6 +87,42 @@ describe('transformSdkConfig', () => {
     expect(offerStep.offer.copy).toEqual({ headline: 'h', body: 'b', cta: 'cta', declineCta: 'no' })
   })
 
+  it('preserves resolved rebate fields on the step-attached offer', () => {
+    const config: SdkConfig = {
+      blueprintId: 'bp_1',
+      steps: [
+        {
+          type: 'offer',
+          guid: 'o1',
+          offer: {
+            type: 'rebate',
+            amountMinor: 1000,
+            currency: 'usd',
+            amountPaidMinor: 9900,
+            netAfterRebateMinor: 8900,
+            paymentMethodBrand: 'Visa',
+            paymentMethodLast4: '4242',
+            copy: { headline: 'h', body: 'b', cta: 'cta', declineCta: 'no' },
+          },
+        },
+      ],
+      customer: { id: 'cus_1' },
+      subscriptions: [],
+      settings: { clickToCancelEnabled: false, strictFTCComplianceEnabled: false },
+    }
+
+    const { steps } = transformSdkConfig(config)
+    const offer = (
+      steps[0] as {
+        offer: { type: string; amountMinor: number; netAfterRebateMinor?: number; paymentMethodLast4?: string }
+      }
+    ).offer
+    expect(offer.type).toBe('rebate')
+    expect(offer.amountMinor).toBe(1000)
+    expect(offer.netAfterRebateMinor).toBe(8900)
+    expect(offer.paymentMethodLast4).toBe('4242')
+  })
+
   it('inlines plan_change plans as DirectPrice[]', () => {
     const config: SdkConfig = {
       blueprintId: 'bp_1',


### PR DESCRIPTION
Adds a `rebate` offer type to the cancel flow, and tidies the offer panels so they share one surface treatment.

## Rebate offers

A rebate is a partial refund of the customer's most recent paid invoice while their subscription stays active. It's aimed at money-back-guarantee windows: a customer who would otherwise cancel to get their money back can take a partial refund and keep the subscription instead. In connected mode the refund is issued through Stripe.

- `RebateOffer` joins the offer union — the local config plus the shape resolved in token mode (`amountMinor`, `currency`, `amountPaidMinor`, `netAfterRebateMinor`) — wired through the state machine, the config transform, and the offer-type map.
- `DefaultRebateOffer` renders the offer as an itemized invoice: the period charge, the rebate being credited (the accented line), and what's still due. Themed with the `--ck-*` tokens and overridable via `components.RebateOffer`.
- `handleRebate` / `onRebate` callbacks, consistent with the other offer types. In connected mode the SDK runs the rebate server-side; defining `handleRebate` overrides that to run the refund through your own billing system.
- The accepted rebate amount is recorded on the session.

The public surface stays minimal — one component, one type, two callbacks — mirroring the existing offer types. Connected-mode rebates are Stripe-only for now.

## Offer panel styling

While building the rebate panel I unified how offer panels are filled. Discount and trial-extension were using `colorPrimarySoft` (the indigo tint); they now use `colorSurfaceMuted` (the neutral callout surface), matching pause and leaving `colorPrimarySoft` for selected-state highlights, as the theming docs describe. The rebate panel itself renders as plain invoice lines on the surface rather than a filled card.

This is a visual change to two existing default components. Override the relevant `--ck-*` properties to restore the previous tint.

## Versioning

Minor bump to `0.4.0`, with a changelog entry (Added: rebate offer; Changed: offer panel surfaces).

## Testing

Typecheck, lint, and build pass. 156 unit tests pass, including coverage for the rebate config transform and the accept paths (handler override and connected-mode action).