### PR TITLE
Clarify the rebate invoice copy (0.4.1)

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect breaking changes in minor versions while we're pre-1.0.
 
+## 0.4.1 — 2026-05-30
+
+### Changed
+
+- Clearer rebate invoice copy in `DefaultRebateOffer`. The lines now read "You paid this period" / "Cancellation rebate" / "Your net for this period" — the period charge is already paid, so the previous "Due for this period" wording was misleading.
+
 ## 0.4.0 — 2026-05-29
 
 ### Added

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/react",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Production-ready cancel flow for React. Drop-in component, headless hook, or full customization. Works standalone or with Churnkey for AI-powered retention.",
   "license": "MIT",
   "repository": {

--- a/packages/react/src/components/steps/offer/default-rebate-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-rebate-offer.tsx
@@ -31,13 +31,14 @@ export function DefaultRebateOffer({
       {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
-        {/* Itemized like an invoice: the period charge, the rebate we credit
-            (the accented line), and what's still due. Paid and net are
-            server-resolved in token mode, so each renders only when present. */}
+        {/* Itemized like an invoice: what they already paid this period, the
+            rebate we credit (the accented line), and the net after the refund.
+            Paid and net are server-resolved in token mode, so each renders
+            only when present. */}
         <div className="ck-offer-rebate">
           {o.amountPaidMinor != null && (
             <div className="ck-offer-rebate-row">
-              <span>Subscription · this period</span>
+              <span>You paid this period</span>
               <span>{formatPriceFromMinor(o.amountPaidMinor, currency)}</span>
             </div>
           )}
@@ -47,7 +48,7 @@ export function DefaultRebateOffer({
           </div>
           {o.netAfterRebateMinor != null && (
             <div className="ck-offer-rebate-row ck-offer-rebate-total">
-              <span>Due for this period</span>
+              <span>Your net for this period</span>
               <span>{formatPriceFromMinor(o.netAfterRebateMinor, currency)}</span>
             </div>
           )}


### PR DESCRIPTION
The default rebate panel's line items implied the period total was still owed, when the invoice has already been paid — a rebate returns part of what was charged. Reworded for clarity:

- "Subscription · this period" → **"You paid this period"**
- "Due for this period" → **"Your net for this period"**
- "Cancellation rebate" (the refund line) is unchanged.

Same copy the Vue embed now uses, so the two clients read consistently.

Patch release `0.4.1` — copy only, no API or behavior change. Lint, typecheck, and the 156 unit tests pass.