### PR TITLE
[codex] Add MCP HTTP transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "test": "turbo test",
-    "test:mcp": "pnpm --filter @churnkey/mcp test:mcp",
+    "local-run": "pnpm --filter @churnkey/mcp local-run",
     "typecheck": "turbo typecheck",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "test": "turbo test",
+    "test:mcp": "pnpm --filter @churnkey/mcp test:mcp",
     "typecheck": "turbo typecheck",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,7 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect 
 ### Added
 
 - `aggregate_payment_recoveries` and `list_payment_recoveries` tools, backed by `/v1/data/warehouse/recovery-aggregation` and `/v1/data/warehouse/recoveries`. Aggregation returns count, invoice/recovered/pending/lost amounts in original currency and USD, with breakdowns by time, card brand, decline reason, outcome, blueprint, currency, and recovered/active state.
-- Cancel-flow configuration tools: `list_blueprints`, `get_blueprint`, `update_blueprint_draft`, `publish_blueprint`, `list_segments`, and `reorder_segments`. Draft updates are kept separate from confirmed live-impacting publish/reorder actions, and the API writes audit logs for configuration changes.
+- Cancel-flow configuration tools: `list_blueprints`, `get_blueprint`, `update_blueprint_draft`, `update_blueprint_step`, `publish_blueprint`, `list_segments`, and `reorder_segments`. Draft updates are kept separate from confirmed live-impacting publish/reorder actions, sparse step edits avoid full `steps` payloads, and the API writes audit logs for configuration changes.
 
 ### Changed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect 
 ### Added
 
 - `aggregate_payment_recoveries` and `list_payment_recoveries` tools, backed by `/v1/data/warehouse/recovery-aggregation` and `/v1/data/warehouse/recoveries`. Aggregation returns count, invoice/recovered/pending/lost amounts in original currency and USD, with breakdowns by time, card brand, decline reason, outcome, blueprint, currency, and recovered/active state.
+- Cancel-flow configuration tools: `list_blueprints`, `get_blueprint`, `update_blueprint_draft`, `publish_blueprint`, `list_segments`, and `reorder_segments`. Draft updates are kept separate from confirmed live-impacting publish/reorder actions, and the API writes audit logs for configuration changes.
 
 ### Changed
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -11,6 +11,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect 
 
 ### Changed
 
+- Error messages from the Data API now surface to the agent. The server returns error bodies as plain text; the client previously only read a JSON `message` field and discarded them, so every validation/authorization failure showed as a generic `Churnkey API error <status>`. The client now relays the server's message verbatim and adds clearer fallbacks for 403/404.
+- `list_blueprints` now returns every non-deleted segment flow (previously segments without a resolvable blueprint were dropped) and the default org flow always appears, matching the dashboard. Each flow gained a `hasUnpublishedChanges` boolean (draft edited since last publish). Tool/README copy no longer claims `status` exactly mirrors the dashboard badges — it is a documented coarse subset.
+- `list_segments` now returns each segment's audience `filter` rules and a 0-based `priority` (replacing the vestigial, never-written `order` field), includes disabled segments, and drops the duplicate `_id` (use `id`).
+- `update_blueprint_draft` no longer accepts a full `steps` array on the Data API. Step content is mutated only via `update_blueprint_step`, which validates and clears stale translations. (Top-level draft fields: `name`, `brandImage`, `primaryColor`, `translatedLanguages`.)
+- `brandImage` validation now mirrors the server (URL path must end in `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp`, or be hosted on `images.churnkey.co`) instead of accepting any URL.
 - `list_sessions` and `aggregate_sessions` now point at the new warehouse-backed routes (`/v1/data/warehouse/sessions` and `/v1/data/warehouse/session-aggregation`). The legacy `/v1/data/sessions` and `/v1/data/session-aggregation` routes are unchanged on the API side and continue to serve real-time Mongo data; the MCP just chooses the warehouse path because lag is acceptable for agent use cases and warehouse queries scale better. Tool descriptions surface the ~3-hour lag.
 
 ### Removed (BREAKING)
@@ -32,7 +37,7 @@ First public release.
 - MCP server (`npx -y @churnkey/mcp`) authenticating with a Churnkey Data API key (`x-ck-app` + `x-ck-api-key`).
 - Read-only tools backed by `/v1/data/*`:
   - `list_sessions` — session-level detail with structured filters (enums for `saveType`/`offerType`/`billingInterval`, typed booleans/integers, ID lookups) and a `not` exclusion object for negation.
-  - `aggregate_sessions` — counts grouped by one or more breakdown dimensions (time series via `day`/`week`/`month`/`invoiceMonth`).
+  - `aggregate_sessions` — counts grouped by one or more breakdown dimensions (time series via `day`/`week`/`month`).
   - `get_api_usage` — API call volume by date range.
 - Compliance tools:
   - `dsr_access` — GDPR/CCPA right-to-know.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect 
 
 - `aggregate_payment_recoveries` and `list_payment_recoveries` tools, backed by `/v1/data/warehouse/recovery-aggregation` and `/v1/data/warehouse/recoveries`. Aggregation returns count, invoice/recovered/pending/lost amounts in original currency and USD, with breakdowns by time, card brand, decline reason, outcome, blueprint, currency, and recovered/active state.
 - Cancel-flow configuration tools: `list_blueprints`, `get_blueprint`, `update_blueprint_draft`, `update_blueprint_step`, `publish_blueprint`, `list_segments`, and `reorder_segments`. Draft updates are kept separate from confirmed live-impacting publish/reorder actions, sparse step edits avoid full `steps` payloads, and the API writes audit logs for configuration changes.
+- Granular cancel-flow mutation tools: `update_blueprint_offer` (offer type + discount/pause/trial/redirect/plan-change config, addressable on a step, survey choice, or structured follow-up option), `edit_survey_structure` (`add_choice`/`remove_choice`/`reorder_choices`/`set_followup`), and `add_blueprint_step` / `remove_blueprint_step` (by canonical `place` / `stepGuid`). `update_blueprint_step` also gained survey behavior (`randomize`, `followupRequired`, `minLength`) and freeform/confirm config. All are draft-only and audit-logged; none require a `confirm` (publish remains the live gate).
+- Segment mutation tools: `set_segment_enabled` (toggle a segment's live targeting) and `update_segment_filter` (replace audience rules). Both act on live config, so each requires a `confirm` literal and writes an audit log.
 
 ### Changed
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,7 +10,7 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_sessions` | Session counts, optionally grouped by `breakdownBy` dimensions (saveType, offerType, planId, day/week/month, …). Same filter set as `list_sessions`. |
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
-| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with compact draft and published metadata. |
+| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with status (`Active`, `Setup Pending`, or `Inactive`) plus compact draft and published metadata. |
 | `get_blueprint` | Full cancel flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
 | `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,8 +11,9 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
 | `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with status (`Active`, `Setup Pending`, or `Inactive`), a `published` boolean, compact draft metadata, and compact `publishedBlueprint` metadata. |
-| `get_blueprint` | Full cancel flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
-| `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
+| `get_blueprint` | Full cancel flow blueprint by ID. Use this for inspection or advanced replacement workflows. |
+| `update_blueprint_draft` | Draft-only updates for top-level blueprint fields (`name`, `brandImage`, `primaryColor`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
+| `update_blueprint_step` | Sparse draft step edits by `stepGuid` or `stepIndex`, without sending the full `steps` array. Copy edits clear stale translations; publish refreshes translations. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
 | `list_segments` | Active cancel flow segment metadata in current priority order. Segment audience filter rules are not returned. |
 | `reorder_segments` | Reorder cancel flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
@@ -21,7 +22,7 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 
 Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. DSR tools read/write the operational store directly (no lag).
 
-Blueprint draft updates are intentionally separate from publishing. An agent can update the unlocked working copy directly, or pass the currently published blueprint ID and let the API resolve the working copy, then publish only via the separate confirmed `publish_blueprint` tool. Segment reordering is also a separate confirmed action because order affects which flow customers see.
+Blueprint draft updates are intentionally separate from publishing. Use `update_blueprint_step` for normal step copy/content edits so the agent sends only the targeted fields instead of the full `steps` array with translations. Copy edits clear stale translations for the affected step content, and `publish_blueprint` refreshes translations before making the draft live. Segment reordering is also a separate confirmed action because order affects which flow customers see.
 
 Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers. Mode (live vs test) is set by the API key prefix; pass a `test_`-prefixed key to query test data.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,18 +10,18 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_sessions` | Session counts, optionally grouped by `breakdownBy` dimensions (saveType, offerType, planId, day/week/month, …). Same filter set as `list_sessions`. |
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
-| `list_blueprints` | Cancel-flow blueprints for the org. Use this to find the draft working copy before editing. |
-| `get_blueprint` | Full cancel-flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
-| `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Writes an audit log. |
+| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with compact draft and published metadata. |
+| `get_blueprint` | Full cancel flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
+| `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
-| `list_segments` | Active cancel-flow segments in current priority order. |
-| `reorder_segments` | Reorder cancel-flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
+| `list_segments` | Active cancel flow segments in current priority order. |
+| `reorder_segments` | Reorder cancel flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
 | `dsr_access` | GDPR/CCPA data access by email. |
 | `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |
 
 Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. DSR tools read/write the operational store directly (no lag).
 
-Blueprint draft updates are intentionally separate from publishing. An agent can update an unlocked draft working copy, then publish only via the separate confirmed `publish_blueprint` tool. Segment reordering is also a separate confirmed action because order affects which flow customers see.
+Blueprint draft updates are intentionally separate from publishing. An agent can update the unlocked working copy directly, or pass the currently published blueprint ID and let the API resolve the working copy, then publish only via the separate confirmed `publish_blueprint` tool. Segment reordering is also a separate confirmed action because order affects which flow customers see.
 
 Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers. Mode (live vs test) is set by the API key prefix; pass a `test_`-prefixed key to query test data.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,7 +14,7 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `get_blueprint` | Full cancel flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
 | `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
-| `list_segments` | Active cancel flow segments in current priority order. |
+| `list_segments` | Active cancel flow segment metadata in current priority order. Segment audience filter rules are not returned. |
 | `reorder_segments` | Reorder cancel flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
 | `dsr_access` | GDPR/CCPA data access by email. |
 | `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -102,7 +102,7 @@ Use a `test_`-prefixed API key for staging data.
 When testing against a local `churnkey-api` server, start the API on port 3000, then run:
 
 ```bash
-pnpm test:mcp --app-id your_app_id --api-key test_data_your_key
+pnpm local-run --app-id your_app_id --api-key test_data_your_key
 ```
 
 The command builds `@churnkey/mcp`, starts the MCP server over stdio, and defaults `CHURNKEY_API_URL` to `http://localhost:3000/v1`. Pass `--api-url` only if your local API is running somewhere else.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -13,16 +13,23 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `list_blueprints` | Current cancel flow inventory for the org: the default flow plus every non-deleted segment flow. Each flow has `status` (`active` / `setup_pending` / `inactive`), `published` and `hasUnpublishedChanges` booleans, `editableBlueprintId`, `publishedBlueprintId`, and compact `draft` / `publishedBlueprint` metadata. Status is a coarse subset of the dashboard badges; the "Unpublished Changes" badge is `status: "active"` + `hasUnpublishedChanges: true`. |
 | `get_blueprint` | Full cancel flow blueprint by ID, including the `steps` array (each step/offer/survey-choice carries its `guid` for use with `update_blueprint_step`). Large for translated blueprints. |
 | `update_blueprint_draft` | Draft-only updates for top-level blueprint fields (`name`, `brandImage`, `primaryColor`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
-| `update_blueprint_step` | Sparse draft step edits by `stepGuid` or `stepIndex`, without sending the full `steps` array. Copy edits clear stale translations; publish refreshes translations. Writes an audit log. |
+| `update_blueprint_step` | Sparse draft step edits by `stepGuid` or `stepIndex`, without sending the full `steps` array — step/offer copy, `enabled`, and behavioral config (survey `randomize`/`followupRequired`/`minLength`, freeform/confirm config). Copy edits clear stale translations; publish refreshes translations. Writes an audit log. |
+| `update_blueprint_offer` | Edit one offer's type and functional config (discount/pause/trial/redirect/plan-change) on a draft, by `stepGuid` (+ optional `choiceGuid`/`optionGuid`). Writes an audit log. |
+| `edit_survey_structure` | Add/remove/reorder survey choices and configure follow-ups (`add_choice`/`remove_choice`/`reorder_choices`/`set_followup`) on a draft survey step. Writes an audit log. |
+| `add_blueprint_step` / `remove_blueprint_step` | Add a step at a canonical `place` (server builds the base step) or remove one by `stepGuid` on a draft. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
 | `list_segments` | Cancel flow segment metadata in priority order (response order = priority; `priority` is the 0-based index). Includes disabled segments (`enabled` flag) and each segment's audience `filter` rules. A/B variant segments appear as separate entries. |
 | `reorder_segments` | Reorder cancel flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
+| `set_segment_enabled` | Enable/disable a segment (live targeting on/off). Requires `confirm: "set_segment_enabled"` and writes an audit log. |
+| `update_segment_filter` | Replace a segment's audience filter rules (whole-array replace). Requires `confirm: "update_segment_filter"` and writes an audit log. |
 | `dsr_access` | GDPR/CCPA data access by email. |
 | `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |
 
 Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. DSR tools read/write the operational store directly (no lag).
 
-Blueprint draft updates are intentionally separate from publishing. Use `update_blueprint_step` for normal step copy/content edits so the agent sends only the targeted fields instead of the full `steps` array with translations. Copy edits clear stale translations for the affected step content, and `publish_blueprint` refreshes translations before making the draft live. Segment reordering is also a separate confirmed action because order affects which flow customers see.
+Blueprint edits are **granular and draft-only**: each tool mutates the unlocked working copy and sends only the targeted fields (never the full `steps` array with translations). `update_blueprint_step` handles copy + behavioral flags, `update_blueprint_offer` handles offer config, `edit_survey_structure` handles survey choices/follow-ups, and `add_blueprint_step`/`remove_blueprint_step` handle step structure. Copy edits clear stale translations for the affected content; `publish_blueprint` refreshes translations before making the draft live and is the only live-impacting blueprint action (so it's the one that requires a `confirm`).
+
+Segment tools (`reorder_segments`, `set_segment_enabled`, `update_segment_filter`) act on **live** config directly (segments have no draft cycle), so each requires an explicit `confirm` literal and writes an audit log.
 
 Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,7 +10,7 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_sessions` | Session counts, optionally grouped by `breakdownBy` dimensions (saveType, offerType, planId, day/week/month, …). Same filter set as `list_sessions`. |
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
-| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with status (`Active`, `Setup Pending`, or `Inactive`) plus compact draft and published metadata. |
+| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with status (`Active`, `Setup Pending`, or `Inactive`), a `published` boolean, compact draft metadata, and compact `publishedBlueprint` metadata. |
 | `get_blueprint` | Full cancel flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
 | `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,12 +10,12 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_sessions` | Session counts, optionally grouped by `breakdownBy` dimensions (saveType, offerType, planId, day/week/month, …). Same filter set as `list_sessions`. |
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
-| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus segment flows, with status (`Active`, `Setup Pending`, or `Inactive`), a `published` boolean, compact draft metadata, and compact `publishedBlueprint` metadata. |
-| `get_blueprint` | Full cancel flow blueprint by ID. Use this for inspection or advanced replacement workflows. |
+| `list_blueprints` | Current cancel flow inventory for the org: the default flow plus every non-deleted segment flow. Each flow has `status` (`active` / `setup_pending` / `inactive`), `published` and `hasUnpublishedChanges` booleans, `editableBlueprintId`, `publishedBlueprintId`, and compact `draft` / `publishedBlueprint` metadata. Status is a coarse subset of the dashboard badges; the "Unpublished Changes" badge is `status: "active"` + `hasUnpublishedChanges: true`. |
+| `get_blueprint` | Full cancel flow blueprint by ID, including the `steps` array (each step/offer/survey-choice carries its `guid` for use with `update_blueprint_step`). Large for translated blueprints. |
 | `update_blueprint_draft` | Draft-only updates for top-level blueprint fields (`name`, `brandImage`, `primaryColor`, `translatedLanguages`). Passing a published blueprint ID edits the corresponding working copy. Writes an audit log. |
 | `update_blueprint_step` | Sparse draft step edits by `stepGuid` or `stepIndex`, without sending the full `steps` array. Copy edits clear stale translations; publish refreshes translations. Writes an audit log. |
 | `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
-| `list_segments` | Active cancel flow segment metadata in current priority order. Segment audience filter rules are not returned. |
+| `list_segments` | Cancel flow segment metadata in priority order (response order = priority; `priority` is the 0-based index). Includes disabled segments (`enabled` flag) and each segment's audience `filter` rules. A/B variant segments appear as separate entries. |
 | `reorder_segments` | Reorder cancel flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
 | `dsr_access` | GDPR/CCPA data access by email. |
 | `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |
@@ -24,7 +24,9 @@ Session and recovery tools read from the Churnkey analytics warehouse — sessio
 
 Blueprint draft updates are intentionally separate from publishing. Use `update_blueprint_step` for normal step copy/content edits so the agent sends only the targeted fields instead of the full `steps` array with translations. Copy edits clear stale translations for the affected step content, and `publish_blueprint` refreshes translations before making the draft live. Segment reordering is also a separate confirmed action because order affects which flow customers see.
 
-Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers. Mode (live vs test) is set by the API key prefix; pass a `test_`-prefixed key to query test data.
+Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers.
+
+Mode (live vs test) is set by the API key prefix — pass a `test_`-prefixed key to query test data. Mode applies to **session analytics** and DSR. **Blueprint/segment configuration is shared across modes** (not key-dependent), and **payment-recovery analytics are not partitioned by mode** (dunning campaigns come from real provider failed-payment events and carry no test/live distinction).
 
 ## Setup
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,10 +10,18 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `aggregate_sessions` | Session counts, optionally grouped by `breakdownBy` dimensions (saveType, offerType, planId, day/week/month, …). Same filter set as `list_sessions`. |
 | `aggregate_payment_recoveries` | Failed-payment recovery (dunning) counts and dollar amounts — invoice / recovered / pending / lost, in original currency and USD. Group by time, card brand, decline reason, outcome, blueprint, currency, recovered/active state. |
 | `list_payment_recoveries` | Individual failed-payment recovery campaigns. Same filter set as the aggregation. |
+| `list_blueprints` | Cancel-flow blueprints for the org. Use this to find the draft working copy before editing. |
+| `get_blueprint` | Full cancel-flow blueprint by ID. Use this before draft updates so unchanged fields can be preserved. |
+| `update_blueprint_draft` | Draft-only updates for allowed blueprint fields (`name`, `brandImage`, `primaryColor`, `steps`, `translatedLanguages`). Writes an audit log. |
+| `publish_blueprint` | Publish a draft blueprint as the live org/segment version. Requires `confirm: "publish"` and writes an audit log. |
+| `list_segments` | Active cancel-flow segments in current priority order. |
+| `reorder_segments` | Reorder cancel-flow segment priority. Requires `confirm: "reorder_segments"` and writes an audit log. |
 | `dsr_access` | GDPR/CCPA data access by email. |
 | `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |
 
 Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. DSR tools read/write the operational store directly (no lag).
+
+Blueprint draft updates are intentionally separate from publishing. An agent can update an unlocked draft working copy, then publish only via the separate confirmed `publish_blueprint` tool. Segment reordering is also a separate confirmed action because order affects which flow customers see.
 
 Each tool's input schema is fully described to the MCP client — enums for `saveType` / `offerType` / `billingInterval` / breakdown dimensions, `not` object for exclusions, structured types for booleans and numbers. Mode (live vs test) is set by the API key prefix; pass a `test_`-prefixed key to query test data.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -105,11 +105,7 @@ When testing against a local `churnkey-api` server, start the API on port 3000, 
 pnpm test:mcp --app-id your_app_id --api-key test_data_your_key
 ```
 
-The command builds `@churnkey/mcp`, starts the MCP server over stdio, and defaults `CHURNKEY_API_URL` to `http://localhost:3000/v1`. Pass `--api-url` to override the API base URL:
-
-```bash
-pnpm test:mcp --app-id your_app_id --api-key test_data_your_key --api-url http://localhost:3001/v1
-```
+The command builds `@churnkey/mcp`, starts the MCP server over stdio, and defaults `CHURNKEY_API_URL` to `http://localhost:3000/v1`. Pass `--api-url` only if your local API is running somewhere else.
 
 For MCP client configs, point the client directly at the built server and provide the same environment variables:
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,6 +35,20 @@ Each tool's input schema is fully described to the MCP client — enums for `sav
 
 Mode (live vs test) is set by the API key prefix — pass a `test_`-prefixed key to query test data. Mode applies to **session analytics** and DSR. **Blueprint/segment configuration is shared across modes** (not key-dependent), and **payment-recovery analytics are not partitioned by mode** (dunning campaigns come from real provider failed-payment events and carry no test/live distinction).
 
+## Transports
+
+The package supports two transports:
+
+- **stdio** (default): local MCP clients run `npx -y @churnkey/mcp` and pass credentials through environment variables.
+- **Streamable HTTP** (opt-in): run the same server behind a single HTTP endpoint, usually `/mcp`.
+
+For a public Churnkey-hosted endpoint, the recommended shape is:
+
+- `https://mcp.churnkey.co` — public docs / onboarding site.
+- `https://mcp.churnkey.co/mcp` — Streamable HTTP MCP endpoint.
+
+That keeps the human site and protocol endpoint on one memorable domain without making the root URL a machine-only route.
+
 ## Setup
 
 1. Get your **App ID** and **Data API Key** from [Churnkey → Settings → Organization](https://app.churnkey.co/settings/organization). Don't have an account? [Create one](https://app.churnkey.co/register?intent=sdk).
@@ -134,6 +148,50 @@ For MCP client configs, point the client directly at the built server and provid
   }
 }
 ```
+
+### HTTP transport variables
+
+| Var | Required | Default |
+|-----|----------|---------|
+| `CHURNKEY_MCP_TRANSPORT` | no | `stdio` |
+| `CHURNKEY_MCP_HOST` | no | `127.0.0.1` |
+| `CHURNKEY_MCP_PORT` | no | `3333` |
+| `CHURNKEY_MCP_PATH` | no | `/mcp` |
+| `CHURNKEY_MCP_ALLOWED_HOSTS` | no | — |
+| `CHURNKEY_MCP_CORS_ORIGIN` | no | — |
+
+`CHURNKEY_MCP_ALLOWED_HOSTS` is a comma-separated list of accepted `Host` headers, including ports when present (for example, `mcp.churnkey.co,localhost:3333`). `CHURNKEY_MCP_CORS_ORIGIN` is intentionally opt-in; set it to one exact browser origin, or `*`, only when a browser-based MCP client needs CORS.
+
+## Streamable HTTP
+
+Start the HTTP server after building:
+
+```bash
+pnpm --filter @churnkey/mcp build
+CHURNKEY_APP_ID=your_app_id \
+CHURNKEY_API_KEY=test_data_your_key \
+pnpm --filter @churnkey/mcp start:http
+```
+
+By default this listens on `http://127.0.0.1:3333/mcp`. You can also run the built binary directly:
+
+```bash
+CHURNKEY_MCP_TRANSPORT=http node packages/mcp/dist/bin.js
+node packages/mcp/dist/bin.js --http
+node packages/mcp/dist/bin.js --transport=http
+```
+
+For a shared or hosted HTTP endpoint, credentials may be sent on the initialization request instead of read from environment variables:
+
+```bash
+curl http://127.0.0.1:3333/mcp \
+  -H 'content-type: application/json' \
+  -H 'x-ck-app: your_app_id' \
+  -H 'x-ck-api-key: test_data_your_key' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0.1.0"}}}'
+```
+
+The server also accepts `Authorization: Bearer <api_key>` for the API key. `x-ck-api-key` takes precedence if both are provided.
 
 ## Programmatic use
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -97,6 +97,38 @@ Restart the client after editing config.
 
 Use a `test_`-prefixed API key for staging data.
 
+## Local API testing
+
+When testing against a local `churnkey-api` server, start the API on port 3000, then run:
+
+```bash
+pnpm test:mcp --app-id your_app_id --api-key test_data_your_key
+```
+
+The command builds `@churnkey/mcp`, starts the MCP server over stdio, and defaults `CHURNKEY_API_URL` to `http://localhost:3000/v1`. Pass `--api-url` to override the API base URL:
+
+```bash
+pnpm test:mcp --app-id your_app_id --api-key test_data_your_key --api-url http://localhost:3001/v1
+```
+
+For MCP client configs, point the client directly at the built server and provide the same environment variables:
+
+```json
+{
+  "mcpServers": {
+    "churnkey-local": {
+      "command": "node",
+      "args": ["/Users/ig/Documents/Churnkey/sdk/packages/mcp/dist/bin.js"],
+      "env": {
+        "CHURNKEY_APP_ID": "your_app_id",
+        "CHURNKEY_API_KEY": "test_data_your_key",
+        "CHURNKEY_API_URL": "http://localhost:3000/v1"
+      }
+    }
+  }
+}
+```
+
 ## Programmatic use
 
 You can also embed the server in another Node process:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,7 +39,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
-    "test:mcp": "pnpm build >/dev/null && node scripts/test-mcp.mjs",
+    "local-run": "pnpm build >/dev/null && node scripts/local-run.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "start": "node dist/bin.js"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -42,7 +42,8 @@
     "local-run": "pnpm build >/dev/null && node scripts/local-run.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "start": "node dist/bin.js"
+    "start": "node dist/bin.js",
+    "start:http": "node dist/bin.js --http"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,6 +39,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
+    "test:mcp": "pnpm build >/dev/null && node scripts/test-mcp.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "start": "node dist/bin.js"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,7 +8,15 @@
     "url": "https://github.com/churnkey/sdk.git",
     "directory": "packages/mcp"
   },
-  "keywords": ["churnkey", "mcp", "model-context-protocol", "claude", "cursor", "subscription", "retention"],
+  "keywords": [
+    "churnkey",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "cursor",
+    "subscription",
+    "retention"
+  ],
   "type": "module",
   "bin": {
     "churnkey-mcp": "./dist/bin.js"
@@ -24,10 +32,14 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "start": "node dist/bin.js"
   },
@@ -38,6 +50,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/mcp/scripts/local-run.mjs
+++ b/packages/mcp/scripts/local-run.mjs
@@ -9,7 +9,7 @@ const DEFAULT_API_URL = 'http://localhost:3000/v1'
 function usage(exitCode = 0) {
   const stream = exitCode === 0 ? process.stderr : process.stderr
   stream.write(`Usage:
-  pnpm test:mcp --app-id <app_id> --api-key <data_api_key>
+  pnpm local-run --app-id <app_id> --api-key <data_api_key>
 
 Options:
   --app-id <value>   Churnkey app ID. Falls back to CHURNKEY_APP_ID.

--- a/packages/mcp/scripts/smoke.mjs
+++ b/packages/mcp/scripts/smoke.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Scriptable end-to-end smoke test: spawns the built MCP server over stdio (via the MCP SDK client),
+// calls the blueprint/segment tools against a local churnkey-api, and asserts the new contract shapes.
+// Reads CHURNKEY_APP_ID / CHURNKEY_API_KEY / CHURNKEY_API_URL from env (or --app-id/--api-key flags).
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(`--${name}`)
+  return i >= 0 ? argv[i + 1] : undefined
+}
+
+const appId = flag('app-id') || process.env.CHURNKEY_APP_ID
+const apiKey = flag('api-key') || process.env.CHURNKEY_API_KEY
+const apiUrl = flag('api-url') || process.env.CHURNKEY_API_URL || 'http://localhost:3000/v1'
+if (!appId || !apiKey) {
+  console.error('Missing credentials. Pass --app-id and --api-key (or set CHURNKEY_APP_ID / CHURNKEY_API_KEY).')
+  process.exit(2)
+}
+
+const binPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'bin.js')
+
+const results = []
+function check(name, condition, detail) {
+  results.push({ name, ok: Boolean(condition), detail })
+  console.log(`${condition ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+async function call(client, name, args = {}) {
+  const res = await client.callTool({ name, arguments: args })
+  const text = res.content?.map((c) => c.text).join('') ?? ''
+  let json
+  try {
+    json = JSON.parse(text)
+  } catch {
+    json = undefined
+  }
+  return { isError: Boolean(res.isError), text, json }
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [binPath],
+  env: { ...process.env, CHURNKEY_APP_ID: appId, CHURNKEY_API_KEY: apiKey, CHURNKEY_API_URL: apiUrl },
+})
+const client = new Client({ name: 'churnkey-smoke', version: '0.0.0' })
+
+try {
+  console.log(`\nConnecting to MCP server (API ${apiUrl}, app ${appId})...\n`)
+  await client.connect(transport)
+
+  const tools = await client.listTools()
+  check('server lists tools', tools.tools.length >= 10, `${tools.tools.length} tools`)
+
+  // --- list_blueprints (D1 + D2) ---
+  const bp = await call(client, 'list_blueprints')
+  if (bp.isError) {
+    check('list_blueprints succeeds', false, bp.text)
+  } else {
+    const flows = bp.json?.flows ?? []
+    const org = flows.find((f) => f.scope === 'org')
+    const seg = flows.find((f) => f.scope === 'segment')
+    check('list_blueprints returns flows[]', Array.isArray(flows), `${flows.length} flows`)
+    check('D1: org default flow always present', Boolean(org), org ? `status=${org.status}` : 'missing')
+    check(
+      'D2: hasUnpublishedChanges present on every flow',
+      flows.length > 0 && flows.every((f) => typeof f.hasUnpublishedChanges === 'boolean'),
+      org ? `org.hasUnpublishedChanges=${org.hasUnpublishedChanges}` : '',
+    )
+    check(
+      'status uses lowercase enum (active/setup_pending/inactive)',
+      flows.every((f) => ['active', 'setup_pending', 'inactive'].includes(f.status)),
+    )
+    if (seg) {
+      check('D4: embedded segment exposes priority (not order)', typeof seg.segment?.priority === 'number' && !('order' in seg.segment))
+      check('D5: embedded segment exposes filter[]', Array.isArray(seg.segment?.filter))
+    } else {
+      console.log('   (no segment flows on this org — segment shape checks skipped)')
+    }
+    console.log('\n   list_blueprints sample:\n' + JSON.stringify(flows.slice(0, 2), null, 2).split('\n').map((l) => '   ' + l).join('\n'))
+  }
+
+  // --- list_segments (D4 + D5 + [11]) ---
+  const segs = await call(client, 'list_segments')
+  if (segs.isError) {
+    check('list_segments succeeds', false, segs.text)
+  } else {
+    const arr = Array.isArray(segs.json) ? segs.json : []
+    check('list_segments returns array', Array.isArray(segs.json), `${arr.length} segments`)
+    if (arr.length > 0) {
+      const s = arr[0]
+      check('[11]: segment has id, not duplicate _id', 'id' in s && !('_id' in s))
+      check('D4: segment has numeric priority, no order', typeof s.priority === 'number' && !('order' in s))
+      check('D5: segment has filter[]', Array.isArray(s.filter))
+      check('segment has enabled boolean', typeof s.enabled === 'boolean')
+    } else {
+      console.log('   (no segments on this org — per-segment field checks skipped)')
+    }
+  }
+
+  // --- B1: error messages surface ---
+  const bad = await call(client, 'get_blueprint', { blueprintId: 'deadbeefdeadbeefdeadbeef' })
+  check(
+    'B1: server error text surfaced (not generic)',
+    bad.isError && /not found/i.test(bad.text) && !/^Churnkey API error \d+$/.test(bad.text.trim()),
+    bad.text,
+  )
+
+  await client.close()
+} catch (err) {
+  console.error('\nSmoke run threw:', err?.message || err)
+  try { await client.close() } catch {}
+  process.exit(1)
+}
+
+const failed = results.filter((r) => !r.ok)
+console.log(`\n${failed.length === 0 ? '✅ ALL CHECKS PASSED' : `❌ ${failed.length} CHECK(S) FAILED`} (${results.length} total)`)
+process.exit(failed.length === 0 ? 0 : 1)

--- a/packages/mcp/scripts/smoke.mjs
+++ b/packages/mcp/scripts/smoke.mjs
@@ -54,7 +54,19 @@ try {
   await client.connect(transport)
 
   const tools = await client.listTools()
+  const toolNames = new Set(tools.tools.map((t) => t.name))
   check('server lists tools', tools.tools.length >= 10, `${tools.tools.length} tools`)
+  // New granular mutation tools must register (this exercises zod -> JSON-schema serialization).
+  const NEW_TOOLS = [
+    'update_blueprint_offer',
+    'edit_survey_structure',
+    'add_blueprint_step',
+    'remove_blueprint_step',
+    'set_segment_enabled',
+    'update_segment_filter',
+  ]
+  const missing = NEW_TOOLS.filter((n) => !toolNames.has(n))
+  check('new mutation tools registered', missing.length === 0, missing.length ? `missing: ${missing.join(', ')}` : NEW_TOOLS.join(', '))
 
   // --- list_blueprints (D1 + D2) ---
   const bp = await call(client, 'list_blueprints')
@@ -109,6 +121,66 @@ try {
     bad.isError && /not found/i.test(bad.text) && !/^Churnkey API error \d+$/.test(bad.text.trim()),
     bad.text,
   )
+
+  // --- opt-in, fully reversible end-to-end WRITE round-trip (--mutate) ---
+  // Picks a side-effect-free reversible field on the org draft (a behavioral flag, or a numeric
+  // pause/trial config field), writes a changed value, RE-READS to observe it persisted, then restores
+  // the original value and re-reads again. Deliberately avoids translation-clearing copy edits, the
+  // discount customAmount->couponId derivation, and live segment toggles.
+  if (process.argv.includes('--mutate')) {
+    const orgFlow = (bp.json?.flows || []).find((f) => f.scope === 'org')
+    const draftId = orgFlow?.editableBlueprintId
+    const readSteps = async () => (await call(client, 'get_blueprint', { blueprintId: draftId })).json?.steps || []
+
+    if (!draftId) {
+      check('mutate: org draft available', false, 'no editable org blueprint to test against')
+    } else {
+      const steps = await readSteps()
+      let target = null
+
+      const surveyStep = steps.find((s) => s.survey && typeof s.survey.randomize === 'boolean')
+      const pauseStep = steps.find((s) => s.offer?.offerType === 'PAUSE' && typeof s.offer?.pauseConfig?.maxPauseLength === 'number')
+      const trialStep = steps.find((s) => s.offer?.offerType === 'TRIAL_EXTENSION' && typeof s.offer?.trialExtensionConfig?.trialExtensionDays === 'number')
+
+      if (surveyStep) {
+        const original = surveyStep.survey.randomize
+        target = {
+          label: 'survey.randomize',
+          changedKey: 'survey.randomize',
+          original,
+          next: !original,
+          write: (value) =>
+            call(client, 'update_blueprint_step', { blueprintId: draftId, stepGuid: surveyStep.guid, updates: { survey: { randomize: value } } }),
+          read: (s) => s.find((x) => x.guid === surveyStep.guid)?.survey?.randomize,
+        }
+      } else if (pauseStep || trialStep) {
+        const pick = pauseStep
+          ? { step: pauseStep, cfg: 'pauseConfig', field: 'maxPauseLength' }
+          : { step: trialStep, cfg: 'trialExtensionConfig', field: 'trialExtensionDays' }
+        const original = pick.step.offer[pick.cfg][pick.field]
+        target = {
+          label: `offer.${pick.cfg}.${pick.field}`,
+          changedKey: `config.${pick.field}`,
+          original,
+          next: original + 1,
+          write: (value) => call(client, 'update_blueprint_offer', { blueprintId: draftId, stepGuid: pick.step.guid, config: { [pick.field]: value } }),
+          read: (s) => s.find((x) => x.guid === pick.step.guid)?.offer?.[pick.cfg]?.[pick.field],
+        }
+      }
+
+      if (!target) {
+        check('mutate: found a safe reversible field', false, 'no side-effect-free reversible field on the org draft')
+      } else {
+        const w1 = await target.write(target.next)
+        check(`mutate: write ${target.label}`, !w1.isError && (w1.json?.changedFields || []).includes(target.changedKey), w1.text)
+        const afterWrite = target.read(await readSteps())
+        check('mutate: write PERSISTED (observed via re-read)', afterWrite === target.next, `${target.label}: ${target.original} -> ${afterWrite}`)
+        const w2 = await target.write(target.original)
+        const afterRestore = target.read(await readSteps())
+        check('mutate: value restored to original', !w2.isError && afterRestore === target.original, `restored to ${afterRestore}`)
+      }
+    }
+  }
 
   await client.close()
 } catch (err) {

--- a/packages/mcp/scripts/test-mcp.mjs
+++ b/packages/mcp/scripts/test-mcp.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_API_URL = 'http://localhost:3000/v1'
+
+function usage(exitCode = 0) {
+  const stream = exitCode === 0 ? process.stderr : process.stderr
+  stream.write(`Usage:
+  pnpm test:mcp --app-id <app_id> --api-key <data_api_key>
+
+Options:
+  --app-id <value>   Churnkey app ID. Falls back to CHURNKEY_APP_ID.
+  --api-key <value>  Churnkey Data API key. Falls back to CHURNKEY_API_KEY.
+  --api-url <value>  API base URL. Defaults to ${DEFAULT_API_URL}.
+
+The command starts the local MCP server over stdio while churnkey-api is
+running locally on port 3000.
+`)
+  process.exit(exitCode)
+}
+
+function parseArgs(argv) {
+  const parsed = {}
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--') continue
+    if (arg === '--help' || arg === '-h') usage()
+
+    if (arg.startsWith('--app-id=')) {
+      parsed.appId = arg.slice('--app-id='.length)
+    } else if (arg === '--app-id') {
+      parsed.appId = argv[++i]
+    } else if (arg.startsWith('--api-key=')) {
+      parsed.apiKey = arg.slice('--api-key='.length)
+    } else if (arg === '--api-key') {
+      parsed.apiKey = argv[++i]
+    } else if (arg.startsWith('--api-url=')) {
+      parsed.apiUrl = arg.slice('--api-url='.length)
+    } else if (arg === '--api-url') {
+      parsed.apiUrl = argv[++i]
+    } else {
+      process.stderr.write(`Unknown option: ${arg}\n\n`)
+      usage(1)
+    }
+  }
+
+  return parsed
+}
+
+const args = parseArgs(process.argv.slice(2))
+const env = { ...process.env }
+
+if (args.appId) env.CHURNKEY_APP_ID = args.appId
+if (args.apiKey) env.CHURNKEY_API_KEY = args.apiKey
+env.CHURNKEY_API_URL = args.apiUrl || env.CHURNKEY_API_URL || DEFAULT_API_URL
+
+if (!env.CHURNKEY_APP_ID) {
+  process.stderr.write('Missing --app-id or CHURNKEY_APP_ID.\n\n')
+  usage(1)
+}
+
+if (!env.CHURNKEY_API_KEY) {
+  process.stderr.write('Missing --api-key or CHURNKEY_API_KEY.\n\n')
+  usage(1)
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const binPath = join(scriptDir, '..', 'dist', 'bin.js')
+
+if (!existsSync(binPath)) {
+  process.stderr.write('Missing packages/mcp/dist/bin.js. Run `pnpm --filter @churnkey/mcp build` first.\n')
+  process.exit(1)
+}
+
+process.stderr.write(`Starting Churnkey MCP against ${env.CHURNKEY_API_URL}\n`)
+
+const child = spawn(process.execPath, [binPath], {
+  env,
+  stdio: 'inherit',
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 0)
+})

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,12 +1,33 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { loadConfig } from './config'
+import { startHttpServer } from './http'
 import { createServer } from './server'
 
 async function main() {
+  if (useHttpTransport()) {
+    const httpServer = await startHttpServer()
+    await new Promise<void>((resolve) => {
+      const shutdown = () => {
+        httpServer.close(() => resolve())
+      }
+      process.once('SIGINT', shutdown)
+      process.once('SIGTERM', shutdown)
+    })
+    return
+  }
+
   const config = loadConfig()
   const server = createServer(config)
   const transport = new StdioServerTransport()
   await server.connect(transport)
+}
+
+function useHttpTransport(): boolean {
+  return (
+    process.argv.includes('--http') ||
+    process.argv.includes('--transport=http') ||
+    process.env.CHURNKEY_MCP_TRANSPORT === 'http'
+  )
 }
 
 main().catch((err) => {

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -64,8 +64,7 @@ function parseJson(text: string): unknown {
 }
 
 function mapErrorMessage(status: number, body: unknown): string {
-  const apiMessage =
-    body && typeof body === 'object' && 'message' in body ? String((body as { message: unknown }).message) : null
+  const apiMessage = extractApiMessage(body)
 
   if (status === 401) {
     return 'Churnkey API rejected the credentials. Check CHURNKEY_APP_ID and CHURNKEY_API_KEY in your MCP server config.'
@@ -73,5 +72,30 @@ function mapErrorMessage(status: number, body: unknown): string {
   if (status >= 500) {
     return apiMessage ?? `Churnkey API returned ${status}. Try again or check status.churnkey.co.`
   }
-  return apiMessage ?? `Churnkey API error ${status}`
+  // The Data API sends error bodies as plain text (res.send(error.message)), not JSON, so the
+  // actionable validation/authorization message lives in the raw string body — surface it verbatim.
+  if (apiMessage) {
+    return apiMessage
+  }
+  if (status === 403) {
+    return 'Churnkey API forbidden (403). Your account may not have this capability enabled — check the API key and account permissions.'
+  }
+  if (status === 404) {
+    return 'Churnkey API resource not found (404). Check the ID you passed (e.g. blueprint or segment ID).'
+  }
+  return `Churnkey API error ${status}`
+}
+
+// The success path returns JSON, but errors come back as a plain-text body. Accept either: an
+// object with a `message` field, or a non-empty string body.
+function extractApiMessage(body: unknown): string | null {
+  if (body && typeof body === 'object' && 'message' in body) {
+    const message = (body as { message: unknown }).message
+    const text = message == null ? '' : String(message).trim()
+    return text ? text : null
+  }
+  if (typeof body === 'string' && body.trim()) {
+    return body.trim()
+  }
+  return null
 }

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -4,6 +4,13 @@ export interface ChurnkeyMcpConfig {
   baseUrl: string
 }
 
+export interface ChurnkeyMcpHttpConfig {
+  host: string
+  port: number
+  path: string
+  allowedHosts?: string[]
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): ChurnkeyMcpConfig {
   const appId = env.CHURNKEY_APP_ID
   const apiKey = env.CHURNKEY_API_KEY
@@ -11,5 +18,57 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ChurnkeyMcpCon
   if (!apiKey) throw new Error('CHURNKEY_API_KEY environment variable is required')
 
   const baseUrl = env.CHURNKEY_API_URL ?? 'https://api.churnkey.co/v1'
-  return { appId, apiKey, baseUrl: baseUrl.replace(/\/$/, '') }
+  return normalizeConfig({ appId, apiKey, baseUrl })
+}
+
+export function loadHttpServerConfig(env: NodeJS.ProcessEnv = process.env): ChurnkeyMcpHttpConfig {
+  const port = Number(env.CHURNKEY_MCP_PORT ?? 3333)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error('CHURNKEY_MCP_PORT must be an integer between 1 and 65535')
+  }
+
+  const path = env.CHURNKEY_MCP_PATH ?? '/mcp'
+  if (!path.startsWith('/')) {
+    throw new Error('CHURNKEY_MCP_PATH must start with /')
+  }
+
+  const allowedHosts = splitCsv(env.CHURNKEY_MCP_ALLOWED_HOSTS)
+  return {
+    host: env.CHURNKEY_MCP_HOST ?? '127.0.0.1',
+    port,
+    path,
+    allowedHosts: allowedHosts.length ? allowedHosts : undefined,
+  }
+}
+
+export function loadHttpRequestConfig(headers: Headers, env: NodeJS.ProcessEnv = process.env): ChurnkeyMcpConfig {
+  const appId = headers.get('x-ck-app') ?? env.CHURNKEY_APP_ID
+  const apiKey = headers.get('x-ck-api-key') ?? readBearerToken(headers) ?? env.CHURNKEY_API_KEY
+  if (!appId) throw new Error('Missing Churnkey App ID. Send x-ck-app or set CHURNKEY_APP_ID.')
+  if (!apiKey)
+    throw new Error(
+      'Missing Churnkey API key. Send x-ck-api-key, Authorization: Bearer <key>, or set CHURNKEY_API_KEY.',
+    )
+
+  const baseUrl = env.CHURNKEY_API_URL ?? 'https://api.churnkey.co/v1'
+  return normalizeConfig({ appId, apiKey, baseUrl })
+}
+
+function normalizeConfig(config: ChurnkeyMcpConfig): ChurnkeyMcpConfig {
+  return { ...config, baseUrl: config.baseUrl.replace(/\/$/, '') }
+}
+
+function readBearerToken(headers: Headers): string | undefined {
+  const authorization = headers.get('authorization')
+  if (!authorization) return undefined
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim())
+  return match?.[1]?.trim()
+}
+
+function splitCsv(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
 }

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from 'node:crypto'
+import { createServer as createNodeServer, type IncomingHttpHeaders, type ServerResponse } from 'node:http'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { type ChurnkeyMcpHttpConfig, loadHttpRequestConfig, loadHttpServerConfig } from './config'
+import { createServer } from './server'
+
+type HttpServer = ReturnType<typeof createNodeServer>
+
+interface HttpSession {
+  transport: StreamableHTTPServerTransport
+}
+
+export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Promise<HttpServer> {
+  const config = loadHttpServerConfig(env)
+  const sessions = new Map<string, HttpSession>()
+
+  const httpServer = createNodeServer(async (req, res) => {
+    try {
+      setCorsHeaders(req.headers, res, env)
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204).end()
+        return
+      }
+
+      const requestUrl = new URL(req.url ?? '/', `http://${req.headers.host ?? `${config.host}:${config.port}`}`)
+      if (requestUrl.pathname !== config.path) {
+        res.writeHead(404, { 'content-type': 'text/plain' }).end('Not found')
+        return
+      }
+
+      if (!isAllowedHost(req.headers, config)) {
+        res.writeHead(403, { 'content-type': 'text/plain' }).end('Forbidden host')
+        return
+      }
+
+      const sessionId = getHeader(req.headers, 'mcp-session-id')
+      const existing = sessionId ? sessions.get(sessionId) : undefined
+
+      if (existing) {
+        await existing.transport.handleRequest(req, res)
+        return
+      }
+
+      if (sessionId) {
+        res.writeHead(404, { 'content-type': 'text/plain' }).end('MCP session not found')
+        return
+      }
+
+      if (req.method !== 'POST') {
+        res.writeHead(400, { 'content-type': 'text/plain' }).end('Missing MCP session ID')
+        return
+      }
+
+      const requestConfig = loadHttpRequestConfig(toFetchHeaders(req.headers), env)
+      const server = createServer(requestConfig)
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: randomUUID,
+        onsessioninitialized: (initializedSessionId) => {
+          sessions.set(initializedSessionId, { transport })
+        },
+      })
+
+      transport.onclose = () => {
+        const initializedSessionId = transport.sessionId
+        if (initializedSessionId) sessions.delete(initializedSessionId)
+      }
+
+      await server.connect(transport)
+      await transport.handleRequest(req, res)
+    } catch (err) {
+      if (!res.headersSent) {
+        const message = err instanceof Error ? err.message : String(err)
+        res.writeHead(401, { 'content-type': 'text/plain' }).end(message)
+      } else {
+        res.end()
+      }
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject)
+    httpServer.listen(config.port, config.host, () => {
+      httpServer.off('error', reject)
+      resolve()
+    })
+  })
+
+  const closeSessions = async () => {
+    await Promise.all([...sessions.values()].map(({ transport }) => transport.close()))
+    sessions.clear()
+  }
+  httpServer.once('close', () => {
+    void closeSessions()
+  })
+
+  console.error(`Churnkey MCP HTTP server listening at http://${config.host}:${config.port}${config.path}`)
+  return httpServer
+}
+
+function setCorsHeaders(headers: IncomingHttpHeaders, res: ServerResponse, env: NodeJS.ProcessEnv) {
+  const origin = getHeader(headers, 'origin')
+  if (!origin) return
+  const allowedOrigin = env.CHURNKEY_MCP_CORS_ORIGIN
+  if (!allowedOrigin) return
+  if (allowedOrigin !== '*' && allowedOrigin !== origin) return
+  res.setHeader('access-control-allow-origin', allowedOrigin)
+  res.setHeader('vary', 'origin')
+  res.setHeader('access-control-allow-methods', 'GET, POST, DELETE, OPTIONS')
+  res.setHeader(
+    'access-control-allow-headers',
+    'authorization, content-type, mcp-session-id, mcp-protocol-version, x-ck-app, x-ck-api-key',
+  )
+  res.setHeader('access-control-expose-headers', 'mcp-session-id')
+}
+
+function isAllowedHost(headers: IncomingHttpHeaders, config: ChurnkeyMcpHttpConfig): boolean {
+  if (!config.allowedHosts?.length) return true
+  const host = getHeader(headers, 'host')
+  if (!host) return false
+  return config.allowedHosts.includes(host)
+}
+
+function toFetchHeaders(headers: IncomingHttpHeaders): Headers {
+  const result = new Headers()
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) result.append(key, item)
+    } else if (value !== undefined) {
+      result.set(key, value)
+    }
+  }
+  return result
+}
+
+function getHeader(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const value = headers[name.toLowerCase()]
+  if (Array.isArray(value)) return value[0]
+  return value
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,4 @@
-export type { ChurnkeyMcpConfig } from './config'
-export { loadConfig } from './config'
+export type { ChurnkeyMcpConfig, ChurnkeyMcpHttpConfig } from './config'
+export { loadConfig, loadHttpRequestConfig, loadHttpServerConfig } from './config'
+export { startHttpServer } from './http'
 export { createServer, SERVER_NAME, SERVER_VERSION } from './server'

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -44,7 +44,7 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
       name: 'list_blueprints',
       title: 'List cancel flow blueprints',
       description:
-        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with compact draft and published metadata. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
+        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with status, compact draft metadata, and compact published metadata. Status mirrors the dashboard badges: Active, Setup Pending, or Inactive. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/blueprints'),

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -21,7 +21,9 @@ const draftUpdates = z
       .describe('Locale keys already translated for this blueprint. Usually preserve the existing value.'),
   })
   .strict()
-  .describe('Allowed draft-only blueprint fields. Published/locked blueprints cannot be updated.')
+  .describe(
+    'Allowed draft-only blueprint fields. If a published blueprint ID is supplied, the API edits its working copy.',
+  )
 
 const updateDraftInput = blueprintIdInput.extend({
   updates: draftUpdates,
@@ -40,29 +42,29 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
     {
       name: 'list_blueprints',
-      title: 'List cancel-flow blueprints',
+      title: 'List cancel flow blueprints',
       description:
-        'List cancel-flow blueprints for the authenticated org, including draft and published versions. Use this before editing so you can identify the draft working copy.',
+        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with compact draft and published metadata. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/blueprints'),
     },
     {
       name: 'get_blueprint',
-      title: 'Get a cancel-flow blueprint',
+      title: 'Get a cancel flow blueprint',
       description:
-        'Fetch one cancel-flow blueprint by ID. Use this before updating; draft updates should preserve unchanged steps and only edit the intended fields.',
+        'Fetch one cancel flow blueprint by ID. Use this before updating; draft updates should preserve unchanged steps and only edit the intended fields.',
       inputSchema: blueprintIdInput,
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async (args) => client.get(`/data/blueprints/${args.blueprintId}`),
     },
     {
       name: 'update_blueprint_draft',
-      title: 'Update a draft cancel-flow blueprint',
+      title: 'Update a draft cancel flow blueprint',
       description: [
-        'Update allowed fields on an unlocked draft blueprint. This does not publish changes; it only updates the working copy.',
+        'Update allowed fields on an unlocked draft blueprint. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy. This does not publish changes.',
         '',
-        'Allowed fields: name, brandImage, primaryColor, steps, translatedLanguages. Published/locked blueprints are rejected.',
+        'Allowed fields: name, brandImage, primaryColor, steps, translatedLanguages.',
         '',
         WRITE_NOTE,
       ].join('\n'),
@@ -73,9 +75,9 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
     },
     {
       name: 'publish_blueprint',
-      title: 'Publish a draft cancel-flow blueprint',
+      title: 'Publish a draft cancel flow blueprint',
       description: [
-        'Publish an unlocked draft blueprint as the live version for its org or segment. This is separate from draft updates and requires explicit confirmation.',
+        'Publish an unlocked draft blueprint as the live version for its org or segment. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy. This is separate from draft updates and requires explicit confirmation.',
         '',
         WRITE_NOTE,
       ].join('\n'),

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -44,7 +44,7 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
       name: 'list_blueprints',
       title: 'List cancel flow blueprints',
       description:
-        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with status, compact draft metadata, and compact published metadata. Status mirrors the dashboard badges: Active, Setup Pending, or Inactive. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
+        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with status, a published boolean, compact draft metadata, and compact publishedBlueprint metadata. Status mirrors the dashboard badges: Active, Setup Pending, or Inactive. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/blueprints'),

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -20,6 +20,7 @@ const draftUpdates = z
       .optional()
       .describe('Locale keys already translated for this blueprint. Usually preserve the existing value.'),
   })
+  .strict()
   .describe('Allowed draft-only blueprint fields. Published/locked blueprints cannot be updated.')
 
 const updateDraftInput = blueprintIdInput.extend({

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -85,6 +85,34 @@ const stepUpdates = z
       .strict()
       .optional()
       .describe('Offer copy updates for offer steps.'),
+    survey: z
+      .object({
+        randomize: z.boolean().optional().describe('Randomize survey response order.'),
+        followupRequired: z.boolean().optional().describe('Whether a follow-up response is required.'),
+        minLength: z.number().int().min(0).optional().describe('Minimum follow-up character length.'),
+      })
+      .strict()
+      .optional()
+      .describe('Survey behavior flags for survey steps (behavioral; does not affect translations).'),
+    freeformConfig: z
+      .object({
+        inputRequired: z.boolean().optional().describe('Require freeform feedback before continuing.'),
+        minLength: z.number().int().min(0).optional().describe('Minimum freeform character length.'),
+      })
+      .strict()
+      .optional()
+      .describe('Config for freeform steps (behavioral; does not affect translations).'),
+    confirmConfig: z
+      .object({
+        discountNotice: z.boolean().optional().describe('Warn customers with an active discount they will lose it.'),
+        requireAcknowledgement: z
+          .boolean()
+          .optional()
+          .describe('Require explicit acknowledgement on the confirm step.'),
+      })
+      .strict()
+      .optional()
+      .describe('Config for confirm steps (behavioral; does not affect translations).'),
     surveyChoices: z
       .array(surveyChoicePatch)
       .optional()
@@ -120,6 +148,110 @@ function requireOneStepSelector(args: { stepGuid?: unknown; stepIndex?: unknown 
     throw new Error('Pass exactly one of stepGuid or stepIndex.')
   }
 }
+
+// update_blueprint_offer (G3). Config fields span all offer types; the server validates them against
+// the offer's own offerType. Kept as one strict object (not a discriminated union) so offerType can be
+// omitted for config-only edits and the tool schema stays a plain object.
+const offerConfig = z
+  .object({
+    couponId: z
+      .string()
+      .optional()
+      .describe('DISCOUNT: Stripe/provider coupon ID. Omit to derive a custom coupon from customAmount.'),
+    customAmount: z.number().int().min(0).optional().describe('DISCOUNT: custom discount amount in CENTS.'),
+    customDuration: z.enum(['ONCE', 'FOREVER']).optional().describe('DISCOUNT: how long the custom discount applies.'),
+    autoOptimize: z.boolean().optional().describe('DISCOUNT: let Churnkey pick the discount.'),
+    maxPauseLength: z.number().int().min(1).optional().describe('PAUSE: maximum pause length.'),
+    pauseInterval: z.enum(['MONTH', 'WEEK']).optional().describe('PAUSE: unit for maxPauseLength.'),
+    datePicker: z
+      .boolean()
+      .optional()
+      .describe('PAUSE: let the customer pick a resume date (supported providers only).'),
+    trialExtensionDays: z.number().int().min(1).optional().describe('TRIAL_EXTENSION: days to extend the trial.'),
+    redirectUrl: z.string().optional().describe('REDIRECT: URL to send the customer to.'),
+    redirectLabel: z.string().optional().describe('REDIRECT: button label.'),
+    options: z.array(z.string()).optional().describe('PLAN_CHANGE: plan/price IDs the customer can switch to.'),
+  })
+  .strict()
+  .describe("Offer-type-specific config. The server validates which fields are allowed against the offer's offerType.")
+
+const updateOfferInput = blueprintIdInput.extend({
+  stepGuid: z.string().min(1).describe('Guid of the step that owns or contains the offer.'),
+  choiceGuid: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Edit the offer attached to this survey choice (instead of the step offer).'),
+  optionGuid: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Edit the offer attached to this structured follow-up option. Requires choiceGuid.'),
+  offerType: z
+    .enum(['PAUSE', 'DISCOUNT', 'CONTACT', 'PLAN_CHANGE', 'REDIRECT', 'TRIAL_EXTENSION'])
+    .optional()
+    .describe('Change the offer type. Switching type seeds default config for the new type.'),
+  header: z.string().optional().describe('Offer headline. Clears stale offer translations.'),
+  description: z.string().optional().describe('Offer description. Clears stale offer translations.'),
+  config: offerConfig.optional(),
+})
+
+// edit_survey_structure (G5). One object with an `op` discriminator; per-op fields are validated
+// server-side. Kept as a plain object (not a zod discriminatedUnion) so the tool schema exposes `.shape`.
+const editSurveyInput = blueprintIdInput.extend({
+  op: z
+    .enum(['add_choice', 'remove_choice', 'reorder_choices', 'set_followup'])
+    .describe('Structural operation to perform on the survey step.'),
+  stepGuid: z.string().min(1).describe('Guid of the survey step (from get_blueprint).'),
+  value: z.string().optional().describe('add_choice: choice display text (default "New Response").'),
+  type: z.enum(['RADIO', 'INPUT']).optional().describe('add_choice: choice type (default RADIO).'),
+  index: z.number().int().min(0).optional().describe('add_choice: insert position (default append).'),
+  followup: z
+    .object({ question: z.string().optional() })
+    .strict()
+    .optional()
+    .describe('add_choice: attach a follow-up question (also sets the choice type to INPUT).'),
+  choiceGuid: z.string().min(1).optional().describe('remove_choice / set_followup: target choice guid.'),
+  choiceIndex: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('remove_choice / set_followup: target choice index (legacy).'),
+  choiceGuids: z
+    .array(z.string().min(1))
+    .min(1)
+    .optional()
+    .describe('reorder_choices: the complete set of existing choice guids in the new order (must be a permutation).'),
+  mode: z
+    .enum(['freeform', 'structured', 'freeform-structured', 'none'])
+    .optional()
+    .describe('set_followup: follow-up mode. "none" removes the follow-up.'),
+  question: z.string().optional().describe('set_followup: follow-up question text.'),
+  structured: z
+    .object({
+      freeformLabel: z.string().optional().describe('Label for the free-text option in freeform-structured mode.'),
+      options: z
+        .array(z.object({ value: z.string().min(1), guid: z.string().min(1).optional() }).strict())
+        .optional()
+        .describe('Structured follow-up options; the server assigns a guid to any option without one.'),
+    })
+    .strict()
+    .optional()
+    .describe('set_followup: structured follow-up options config.'),
+})
+
+const addStepInput = blueprintIdInput.extend({
+  place: z
+    .enum(['INITIAL_OFFER', 'SURVEY', 'FREEFORM', 'FINAL_OFFER', 'CONFIRM'])
+    .describe(
+      'Canonical step slot. Each slot can hold one step. FINAL_OFFER requires an existing INITIAL_OFFER (a single offer is the initial offer). Offer steps are created with a base DISCOUNT offer — configure it with update_blueprint_offer.',
+    ),
+})
+
+const removeStepInput = blueprintIdInput.extend({
+  stepGuid: z.string().min(1).describe('Guid of the step to remove (from get_blueprint).'),
+})
 
 export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
@@ -170,9 +302,9 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
       description: [
         'Patch a single draft blueprint step without sending the full steps array. Prefer stepGuid; use stepIndex only for legacy blueprints without step guids. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy.',
         '',
-        'Allowed updates: step header, description, enabled, offer header/description, and survey choice value/followupQuestion by choiceGuid or choiceIndex.',
+        'Allowed updates: step header, description, enabled; offer header/description; survey behavior (randomize, followupRequired, minLength); freeform config (inputRequired, minLength); confirm config (discountNotice, requireAcknowledgement); and survey choice value/followupQuestion by choiceGuid or choiceIndex.',
         '',
-        'Copy changes clear stale translations for the affected step/offer/survey choice. Auto translation is refreshed on publish, not during this draft patch.',
+        'Copy changes clear stale translations for the affected step/offer/survey choice; behavioral flags (enabled, randomize, followupRequired, minLength, inputRequired, discountNotice, requireAcknowledgement) do not. Auto translation is refreshed on publish, not during this draft patch. For offer pricing/coupon config use update_blueprint_offer; for adding/removing/reordering survey choices use edit_survey_structure.',
         '',
         WRITE_NOTE,
       ].join('\n'),
@@ -183,6 +315,75 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
         const { blueprintId, stepGuid, stepIndex, updates } = args
         return client.post(`/data/blueprints/${blueprintId}/step`, { body: { stepGuid, stepIndex, updates } })
       },
+    },
+    {
+      name: 'update_blueprint_offer',
+      title: 'Update a draft cancel flow offer',
+      description: [
+        'Patch the type and functional config of a single offer on a draft blueprint, without sending the full steps array. Offers attach in three places: an offer step (pass stepGuid only), a survey choice (pass stepGuid + choiceGuid), or a structured follow-up option (pass stepGuid + choiceGuid + optionGuid). The offer must already exist at that location. If you pass a published blueprint ID, the API resolves it to the working copy.',
+        '',
+        "Change offerType and/or its config: DISCOUNT (couponId, or customAmount in cents + customDuration, or autoOptimize), PAUSE (maxPauseLength + pauseInterval, datePicker), TRIAL_EXTENSION (trialExtensionDays), REDIRECT (redirectUrl, redirectLabel), PLAN_CHANGE (options), CONTACT (no config). You may also set header/description. Config is validated against the offer's offerType; switching type seeds default config.",
+        '',
+        'Config changes do not affect translations; header/description changes clear stale offer translations (refreshed on publish).',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: updateOfferInput,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      handler: async (args) => {
+        if (args.optionGuid && !args.choiceGuid) {
+          throw new Error('optionGuid requires choiceGuid.')
+        }
+        const { blueprintId, ...body } = args
+        return client.post(`/data/blueprints/${blueprintId}/offer`, { body })
+      },
+    },
+    {
+      name: 'edit_survey_structure',
+      title: 'Edit a draft cancel flow survey structure',
+      description: [
+        "Add, remove, or reorder survey response choices, or configure a choice's follow-up, on a draft survey step. This changes the survey STRUCTURE (which options customers can pick) — for editing existing choice copy use update_blueprint_step. If you pass a published blueprint ID, the API resolves it to the working copy.",
+        '',
+        'Set `op`: add_choice (the server assigns the new choice guid), remove_choice (by choiceGuid/choiceIndex), reorder_choices (pass choiceGuids = the full set in the new order), or set_followup (mode freeform | structured | freeform-structured | none; the server assigns guids to structured options).',
+        '',
+        'Structural edits clear stale translations for the affected step/choices; auto translation refreshes on publish.',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: editSurveyInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      handler: async (args) => {
+        const { blueprintId, ...body } = args
+        return client.post(`/data/blueprints/${blueprintId}/survey`, { body })
+      },
+    },
+    {
+      name: 'add_blueprint_step',
+      title: 'Add a step to a draft cancel flow',
+      description: [
+        'Add a step to a draft blueprint at a canonical slot (place). The server builds a sensible base step for that place, so you do not send a full step object — configure it afterward with update_blueprint_step / update_blueprint_offer / edit_survey_structure. If you pass a published blueprint ID, the API resolves it to the working copy.',
+        '',
+        'Places: INITIAL_OFFER, SURVEY, FREEFORM, FINAL_OFFER, CONFIRM — each can hold one step, inserted in canonical order. FINAL_OFFER requires an existing INITIAL_OFFER. Offer steps are seeded with a base DISCOUNT offer.',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: addStepInput,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/blueprints/${args.blueprintId}/step/add`, { body: { place: args.place } }),
+    },
+    {
+      name: 'remove_blueprint_step',
+      title: 'Remove a step from a draft cancel flow',
+      description: [
+        'Remove a step from a draft blueprint by stepGuid (from get_blueprint). If you pass a published blueprint ID, the API resolves it to the working copy. The step and its content are removed from the draft (not published until publish_blueprint).',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: removeStepInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/blueprints/${args.blueprintId}/step/remove`, { body: { stepGuid: args.stepGuid } }),
     },
     {
       name: 'publish_blueprint',

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -11,10 +11,6 @@ const draftUpdates = z
     name: z.string().optional().describe('Blueprint display name.'),
     brandImage: z.string().url().optional().describe('Brand image URL. SVG URLs are rejected by the API.'),
     primaryColor: z.string().optional().describe('Primary hex color for the flow, e.g. "#F7B200".'),
-    steps: z
-      .array(z.record(z.unknown()))
-      .optional()
-      .describe('Full draft steps array. Fetch the blueprint first and preserve unchanged steps.'),
     translatedLanguages: z
       .array(z.string())
       .optional()
@@ -29,6 +25,60 @@ const updateDraftInput = blueprintIdInput.extend({
   updates: draftUpdates,
 })
 
+const surveyChoicePatch = z
+  .object({
+    choiceGuid: z.string().optional().describe('Preferred stable survey choice identifier.'),
+    choiceIndex: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Zero-based choice index for legacy choices without guids.'),
+    value: z.string().optional().describe('Survey choice display text.'),
+    followupQuestion: z.string().optional().describe('Follow-up question text for this choice.'),
+  })
+  .strict()
+  .refine((value) => (value.choiceGuid ? 1 : 0) + (value.choiceIndex !== undefined ? 1 : 0) === 1, {
+    message: 'Pass exactly one of choiceGuid or choiceIndex.',
+  })
+  .refine((value) => value.value !== undefined || value.followupQuestion !== undefined, {
+    message: 'Pass at least one survey choice update field.',
+  })
+
+const stepUpdates = z
+  .object({
+    header: z.string().optional().describe('Step headline text. Clears stale translations for the step.'),
+    description: z.string().optional().describe('Step description text. Clears stale translations for the step.'),
+    enabled: z.boolean().optional().describe('Whether this step is enabled. Does not affect translations.'),
+    offer: z
+      .object({
+        header: z.string().optional().describe('Offer headline text. Clears stale offer translations.'),
+        description: z.string().optional().describe('Offer description text. Clears stale offer translations.'),
+      })
+      .strict()
+      .optional()
+      .describe('Offer copy updates for offer steps.'),
+    surveyChoices: z
+      .array(surveyChoicePatch)
+      .optional()
+      .describe(
+        'Survey choice copy updates by choiceGuid or choiceIndex. Clears stale translations for changed choices.',
+      ),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, { message: 'Pass at least one step update field.' })
+
+const updateStepInput = blueprintIdInput.extend({
+  stepGuid: z.string().optional().describe('Preferred stable step identifier.'),
+  stepIndex: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Zero-based step index for legacy blueprints without step guids.'),
+  updates: stepUpdates,
+})
+
 const publishInput = blueprintIdInput.extend({
   confirm: z
     .literal('publish')
@@ -37,6 +87,12 @@ const publishInput = blueprintIdInput.extend({
 
 const WRITE_NOTE =
   'This is a configuration write. The API records an audit log with the changed fields and Data API source.'
+
+function requireOneStepSelector(args: { stepGuid?: unknown; stepIndex?: unknown }) {
+  if ((args.stepGuid ? 1 : 0) + (args.stepIndex !== undefined ? 1 : 0) !== 1) {
+    throw new Error('Pass exactly one of stepGuid or stepIndex.')
+  }
+}
 
 export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
@@ -62,9 +118,9 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
       name: 'update_blueprint_draft',
       title: 'Update a draft cancel flow blueprint',
       description: [
-        'Update allowed fields on an unlocked draft blueprint. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy. This does not publish changes.',
+        'Update top-level fields on an unlocked draft blueprint. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy. This does not publish changes.',
         '',
-        'Allowed fields: name, brandImage, primaryColor, steps, translatedLanguages.',
+        'Allowed fields: name, brandImage, primaryColor, translatedLanguages. For step copy/content edits, use update_blueprint_step so the agent does not need to send the full steps array.',
         '',
         WRITE_NOTE,
       ].join('\n'),
@@ -72,6 +128,26 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
       handler: async (args) =>
         client.post(`/data/blueprints/${args.blueprintId}/draft`, { body: { updates: args.updates } }),
+    },
+    {
+      name: 'update_blueprint_step',
+      title: 'Update one draft cancel flow step',
+      description: [
+        'Patch a single draft blueprint step without sending the full steps array. Prefer stepGuid; use stepIndex only for legacy blueprints without step guids. If you pass a published blueprint ID, the API resolves it to the corresponding unlocked working copy.',
+        '',
+        'Allowed updates: step header, description, enabled, offer header/description, and survey choice value/followupQuestion by choiceGuid or choiceIndex.',
+        '',
+        'Copy changes clear stale translations for the affected step/offer/survey choice. Auto translation is refreshed on publish, not during this draft patch.',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: updateStepInput,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      handler: async (args) => {
+        requireOneStepSelector(args)
+        const { blueprintId, stepGuid, stepIndex, updates } = args
+        return client.post(`/data/blueprints/${blueprintId}/step`, { body: { stepGuid, stepIndex, updates } })
+      },
     },
     {
       name: 'publish_blueprint',

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+import type { ChurnkeyClient } from '../client'
+import type { ToolDefinition } from './types'
+
+const blueprintIdInput = z.object({
+  blueprintId: z.string().describe('Churnkey blueprint ID. Use list_blueprints first if you do not know it.'),
+})
+
+const draftUpdates = z
+  .object({
+    name: z.string().optional().describe('Blueprint display name.'),
+    brandImage: z.string().url().optional().describe('Brand image URL. SVG URLs are rejected by the API.'),
+    primaryColor: z.string().optional().describe('Primary hex color for the flow, e.g. "#F7B200".'),
+    steps: z
+      .array(z.record(z.unknown()))
+      .optional()
+      .describe('Full draft steps array. Fetch the blueprint first and preserve unchanged steps.'),
+    translatedLanguages: z
+      .array(z.string())
+      .optional()
+      .describe('Locale keys already translated for this blueprint. Usually preserve the existing value.'),
+  })
+  .describe('Allowed draft-only blueprint fields. Published/locked blueprints cannot be updated.')
+
+const updateDraftInput = blueprintIdInput.extend({
+  updates: draftUpdates,
+})
+
+const publishInput = blueprintIdInput.extend({
+  confirm: z
+    .literal('publish')
+    .describe('Required confirmation. Publishing affects the live cancel flow; pass exactly "publish".'),
+})
+
+const WRITE_NOTE =
+  'This is a configuration write. The API records an audit log with the changed fields and Data API source.'
+
+export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_blueprints',
+      title: 'List cancel-flow blueprints',
+      description:
+        'List cancel-flow blueprints for the authenticated org, including draft and published versions. Use this before editing so you can identify the draft working copy.',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async () => client.get('/data/blueprints'),
+    },
+    {
+      name: 'get_blueprint',
+      title: 'Get a cancel-flow blueprint',
+      description:
+        'Fetch one cancel-flow blueprint by ID. Use this before updating; draft updates should preserve unchanged steps and only edit the intended fields.',
+      inputSchema: blueprintIdInput,
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async (args) => client.get(`/data/blueprints/${args.blueprintId}`),
+    },
+    {
+      name: 'update_blueprint_draft',
+      title: 'Update a draft cancel-flow blueprint',
+      description: [
+        'Update allowed fields on an unlocked draft blueprint. This does not publish changes; it only updates the working copy.',
+        '',
+        'Allowed fields: name, brandImage, primaryColor, steps, translatedLanguages. Published/locked blueprints are rejected.',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: updateDraftInput,
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/blueprints/${args.blueprintId}/draft`, { body: { updates: args.updates } }),
+    },
+    {
+      name: 'publish_blueprint',
+      title: 'Publish a draft cancel-flow blueprint',
+      description: [
+        'Publish an unlocked draft blueprint as the live version for its org or segment. This is separate from draft updates and requires explicit confirmation.',
+        '',
+        WRITE_NOTE,
+      ].join('\n'),
+      inputSchema: publishInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/blueprints/${args.blueprintId}/publish`, { body: { confirm: args.confirm } }),
+    },
+  ]
+}

--- a/packages/mcp/src/tools/blueprints.ts
+++ b/packages/mcp/src/tools/blueprints.ts
@@ -6,10 +6,37 @@ const blueprintIdInput = z.object({
   blueprintId: z.string().describe('Churnkey blueprint ID. Use list_blueprints first if you do not know it.'),
 })
 
+// Mirrors the server's validateImageUrl (churnkey-api src/helpers/aws.js): images hosted on
+// images.churnkey.co are always trusted; otherwise the URL path must end in an allowed raster
+// extension. SVG (and anything else) is rejected. The server does not require https, so we don't either.
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp']
+const brandImage = z
+  .string()
+  .refine(
+    (value) => {
+      if (value.startsWith('https://images.churnkey.co/')) return true
+      let pathname: string
+      try {
+        pathname = new URL(value).pathname
+      } catch {
+        return false
+      }
+      const ext = pathname.split('.').pop()?.toLowerCase()
+      return Boolean(ext && IMAGE_EXTENSIONS.includes(ext))
+    },
+    {
+      message:
+        'brandImage must be a URL whose path ends in .png/.jpg/.jpeg/.gif/.webp (SVG and other formats are rejected); churnkey.co-hosted images are always accepted.',
+    },
+  )
+  .describe(
+    'Brand image URL. Must point to a PNG/JPG/JPEG/GIF/WebP image (SVG and other formats are rejected by the API); images on images.churnkey.co are always accepted.',
+  )
+
 const draftUpdates = z
   .object({
     name: z.string().optional().describe('Blueprint display name.'),
-    brandImage: z.string().url().optional().describe('Brand image URL. SVG URLs are rejected by the API.'),
+    brandImage: brandImage.optional(),
     primaryColor: z.string().optional().describe('Primary hex color for the flow, e.g. "#F7B200".'),
     translatedLanguages: z
       .array(z.string())
@@ -27,7 +54,7 @@ const updateDraftInput = blueprintIdInput.extend({
 
 const surveyChoicePatch = z
   .object({
-    choiceGuid: z.string().optional().describe('Preferred stable survey choice identifier.'),
+    choiceGuid: z.string().min(1).optional().describe('Preferred stable survey choice identifier.'),
     choiceIndex: z
       .number()
       .int()
@@ -69,7 +96,7 @@ const stepUpdates = z
   .refine((value) => Object.keys(value).length > 0, { message: 'Pass at least one step update field.' })
 
 const updateStepInput = blueprintIdInput.extend({
-  stepGuid: z.string().optional().describe('Preferred stable step identifier.'),
+  stepGuid: z.string().min(1).optional().describe('Preferred stable step identifier.'),
   stepIndex: z
     .number()
     .int()
@@ -99,8 +126,13 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
     {
       name: 'list_blueprints',
       title: 'List cancel flow blueprints',
-      description:
-        'List the current cancel flow inventory for the authenticated org: the default org flow plus segment flows, each with status, a published boolean, compact draft metadata, and compact publishedBlueprint metadata. Status mirrors the dashboard badges: Active, Setup Pending, or Inactive. Use editableBlueprintId for draft updates, or fetch a full blueprint before changing steps.',
+      description: [
+        'List the current cancel flow inventory for the authenticated org: the default org flow plus every non-deleted segment flow (including segments that are not yet set up or disabled). Each flow has a `status` (`active`, `setup_pending`, or `inactive`), a `published` boolean, a `hasUnpublishedChanges` boolean (true when the draft has edits not yet published), compact `draft` metadata, and compact `publishedBlueprint` metadata.',
+        '',
+        'Status is a coarse subset of the dashboard badges: `active` = a published flow, `setup_pending` = configured but never published (the dashboard\'s "Setup Pending" / "Needs to be Published"), `inactive` = a disabled segment. The dashboard\'s "Unpublished Changes" badge corresponds to `status: "active"` with `hasUnpublishedChanges: true`.',
+        '',
+        'Use `editableBlueprintId` for draft updates and `publishedBlueprintId` to reference the live version. Blueprint configuration is shared across live and test mode, so this is not affected by the API key prefix.',
+      ].join('\n'),
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/blueprints'),
@@ -108,8 +140,11 @@ export function blueprintTools(client: ChurnkeyClient): ToolDefinition[] {
     {
       name: 'get_blueprint',
       title: 'Get a cancel flow blueprint',
-      description:
-        'Fetch one cancel flow blueprint by ID. Use this before updating; draft updates should preserve unchanged steps and only edit the intended fields.',
+      description: [
+        'Fetch one full cancel flow blueprint by ID. Returns the blueprint metadata (name, guid, version, brandImage, primaryColor, translatedLanguages, locked, publishedAt) and the full `steps` array.',
+        '',
+        'Each step includes its `guid`, `enabled`, copy, an optional `offer` (with `offerType`), and an optional `survey` whose `choices` each carry a `guid` and `value`. Use these `guid`s with update_blueprint_step to patch a specific step or survey choice without resending the whole steps array. Note the response can be large for translated blueprints (every step/offer/choice carries its translations).',
+      ].join('\n'),
       inputSchema: blueprintIdInput,
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async (args) => client.get(`/data/blueprints/${args.blueprintId}`),

--- a/packages/mcp/src/tools/dsr.ts
+++ b/packages/mcp/src/tools/dsr.ts
@@ -29,8 +29,11 @@ export function dsrTools(client: ChurnkeyClient): ToolDefinition[] {
     {
       name: 'dsr_delete',
       title: 'GDPR/CCPA data delete request',
-      description:
+      description: [
         'Permanently delete all Churnkey data for a customer email (GDPR Article 17 / CCPA right-to-delete). DESTRUCTIVE and irreversible. Always confirm the exact email with the user before invoking.',
+        '',
+        'Deletion is all-or-nothing. Check the `deleted` boolean in the response: when true, `deletedCounts` lists what was removed; when false, nothing was deleted and `reasonForRejection` explains why (e.g. the profile is too large to delete via the API — contact support). Relay `reasonForRejection` rather than reporting success. A small number of accounts have DSR disabled and return a 403 with a support-contact message.',
+      ].join('\n'),
       inputSchema: deleteInput,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
       handler: async (args) => client.post('/data/dsr/delete', { body: args }),

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,11 +1,19 @@
 import type { ChurnkeyClient } from '../client'
+import { blueprintTools } from './blueprints'
 import { dsrTools } from './dsr'
 import { recoveryTools } from './recoveries'
+import { segmentTools } from './segments'
 import { sessionTools } from './sessions'
 import type { ToolDefinition } from './types'
 
 export function allTools(client: ChurnkeyClient): ToolDefinition[] {
-  return [...sessionTools(client), ...recoveryTools(client), ...dsrTools(client)]
+  return [
+    ...sessionTools(client),
+    ...recoveryTools(client),
+    ...blueprintTools(client),
+    ...segmentTools(client),
+    ...dsrTools(client),
+  ]
 }
 
 export type { ToolDefinition } from './types'

--- a/packages/mcp/src/tools/segments.ts
+++ b/packages/mcp/src/tools/segments.ts
@@ -20,18 +20,18 @@ export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
     {
       name: 'list_segments',
-      title: 'List cancel-flow segments',
+      title: 'List cancel flow segments',
       description:
-        'List active cancel-flow segments for the authenticated org in current priority order. Use before reorder_segments.',
+        'List active cancel flow segments for the authenticated org in current priority order. Use before reorder_segments.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/segments'),
     },
     {
       name: 'reorder_segments',
-      title: 'Reorder cancel-flow segments',
+      title: 'Reorder cancel flow segments',
       description:
-        'Reorder cancel-flow segment priority. This is a live-impacting configuration change, so it requires explicit confirmation and records an audit log.',
+        'Reorder cancel flow segment priority. This is a live-impacting configuration change, so it requires explicit confirmation and records an audit log.',
       inputSchema: reorderInput,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
       handler: async (args) => client.post('/data/segments/reorder', { body: args }),

--- a/packages/mcp/src/tools/segments.ts
+++ b/packages/mcp/src/tools/segments.ts
@@ -21,8 +21,11 @@ export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
     {
       name: 'list_segments',
       title: 'List cancel flow segments',
-      description:
-        'List active cancel flow segment metadata for the authenticated org in current priority order. Segment audience filter rules are not returned. Use before reorder_segments.',
+      description: [
+        'List cancel flow segment metadata for the authenticated org in priority order (the response order IS the priority — first = highest priority; the 0-based `priority` field mirrors it). Includes disabled segments (each has an `enabled` boolean). Each segment also returns its audience `filter` rules ([{ attribute, operand, value }]) so you can reason about which customers a flow targets.',
+        '',
+        'A/B test variant segments appear as separate top-level entries here (the dashboard folds them under their parent test), so treat segments cautiously when reordering. Use this before reorder_segments.',
+      ].join('\n'),
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/segments'),

--- a/packages/mcp/src/tools/segments.ts
+++ b/packages/mcp/src/tools/segments.ts
@@ -16,6 +16,58 @@ const reorderInput = z.object({
     ),
 })
 
+const setEnabledInput = z.object({
+  segmentId: z.string().describe('Churnkey segment ID. Use list_segments first if you do not know it.'),
+  enabled: z
+    .boolean()
+    .describe('true to enable the segment (serve its flow to matching customers), false to disable it.'),
+  confirm: z
+    .literal('set_segment_enabled')
+    .describe(
+      'Required confirmation. Enabling/disabling changes which flow live customers see; pass exactly "set_segment_enabled".',
+    ),
+})
+
+const SEGMENT_OPERANDS = ['INCLUDES', 'GT', 'LT', 'GTE', 'LTE', 'BETWEEN', 'NOT_INCLUDES', 'NOT_BETWEEN'] as const
+
+const filterRule = z
+  .object({
+    attribute: z
+      .string()
+      .min(1)
+      .describe('Targeting attribute, e.g. PLAN_ID, PRICE, SUBSCRIPTION_AGE_MONTHS. See list_segments for examples.'),
+    operand: z
+      .enum(SEGMENT_OPERANDS)
+      .describe('Comparison operand. EQUAL/NOT_EQUAL are NOT supported — use INCLUDES/NOT_INCLUDES.'),
+    value: z
+      .array(z.unknown())
+      .describe(
+        'Comparison value(s). BETWEEN/NOT_BETWEEN need exactly 2; GT/LT/GTE/LTE need 1; INCLUDES/NOT_INCLUDES is a list.',
+      ),
+    type: z
+      .enum(['STRING', 'NUMBER', 'BOOLEAN', 'DATE'])
+      .optional()
+      .describe('Value type. Usually preserve what list_segments returned for this attribute.'),
+  })
+  .strict()
+  .refine((rule) => !['BETWEEN', 'NOT_BETWEEN'].includes(rule.operand) || rule.value.length === 2, {
+    message: 'value must have exactly 2 entries for BETWEEN/NOT_BETWEEN.',
+  })
+
+const updateFilterInput = z.object({
+  segmentId: z.string().describe('Churnkey segment ID. Use list_segments first if you do not know it.'),
+  filter: z
+    .array(filterRule)
+    .describe(
+      'Complete replacement set of audience rules (whole-array replace; include every rule to keep). Pass [] to clear all rules.',
+    ),
+  confirm: z
+    .literal('update_segment_filter')
+    .describe(
+      'Required confirmation. Editing the filter changes which customers the flow targets; pass exactly "update_segment_filter".',
+    ),
+})
+
 export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
     {
@@ -38,6 +90,33 @@ export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
       inputSchema: reorderInput,
       annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
       handler: async (args) => client.post('/data/segments/reorder', { body: args }),
+    },
+    {
+      name: 'set_segment_enabled',
+      title: 'Enable or disable a cancel flow segment',
+      description:
+        'Enable or disable a cancel flow segment. Disabling stops its flow from being served to matching customers (the segment becomes inactive); enabling resumes it. This is a live-impacting configuration change, so it requires explicit confirmation and records an audit log. Use list_segments first to get the segment ID and its current enabled state.',
+      inputSchema: setEnabledInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/segments/${args.segmentId}/enabled`, {
+          body: { enabled: args.enabled, confirm: args.confirm },
+        }),
+    },
+    {
+      name: 'update_segment_filter',
+      title: 'Update a cancel flow segment audience filter',
+      description: [
+        'Replace the audience filter rules for a cancel flow segment. This sends the COMPLETE new filter array and fully replaces the existing rules (it is not an add/remove patch) — include every rule you want to keep. This changes which customers the segment targets, so it is live-impacting, requires explicit confirmation, and records an audit log.',
+        '',
+        'Each rule is { attribute, operand, value, type? }. operand is one of INCLUDES, GT, LT, GTE, LTE, BETWEEN, NOT_INCLUDES, NOT_BETWEEN. For BETWEEN/NOT_BETWEEN, value has exactly two entries [low, high]; for GT/LT/GTE/LTE, one entry; for INCLUDES/NOT_INCLUDES, the list of matching values. Call list_segments first to read the current rules.',
+      ].join('\n'),
+      inputSchema: updateFilterInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      handler: async (args) =>
+        client.post(`/data/segments/${args.segmentId}/filter`, {
+          body: { filter: args.filter, confirm: args.confirm },
+        }),
     },
   ]
 }

--- a/packages/mcp/src/tools/segments.ts
+++ b/packages/mcp/src/tools/segments.ts
@@ -22,7 +22,7 @@ export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
       name: 'list_segments',
       title: 'List cancel flow segments',
       description:
-        'List active cancel flow segments for the authenticated org in current priority order. Use before reorder_segments.',
+        'List active cancel flow segment metadata for the authenticated org in current priority order. Segment audience filter rules are not returned. Use before reorder_segments.',
       inputSchema: z.object({}),
       annotations: { readOnlyHint: true, openWorldHint: true },
       handler: async () => client.get('/data/segments'),

--- a/packages/mcp/src/tools/segments.ts
+++ b/packages/mcp/src/tools/segments.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import type { ChurnkeyClient } from '../client'
+import type { ToolDefinition } from './types'
+
+const reorderInput = z.object({
+  segmentIds: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Segment IDs in desired priority order. Any existing segments omitted from this list are kept after the provided IDs in their current relative order.',
+    ),
+  confirm: z
+    .literal('reorder_segments')
+    .describe(
+      'Required confirmation. Segment priority can change which flow customers see; pass exactly "reorder_segments".',
+    ),
+})
+
+export function segmentTools(client: ChurnkeyClient): ToolDefinition[] {
+  return [
+    {
+      name: 'list_segments',
+      title: 'List cancel-flow segments',
+      description:
+        'List active cancel-flow segments for the authenticated org in current priority order. Use before reorder_segments.',
+      inputSchema: z.object({}),
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      handler: async () => client.get('/data/segments'),
+    },
+    {
+      name: 'reorder_segments',
+      title: 'Reorder cancel-flow segments',
+      description:
+        'Reorder cancel-flow segment priority. This is a live-impacting configuration change, so it requires explicit confirmation and records an audit log.',
+      inputSchema: reorderInput,
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      handler: async (args) => client.post('/data/segments/reorder', { body: args }),
+    },
+  ]
+}

--- a/packages/mcp/tests/client.test.ts
+++ b/packages/mcp/tests/client.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ChurnkeyClient } from '../src/client'
+
+function makeClient() {
+  return new ChurnkeyClient({ appId: 'app_123', apiKey: 'test_key', baseUrl: 'https://api.example.com/v1' })
+}
+
+function mockFetch(body: string, status: number, headers?: Record<string, string>) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, { status, headers }))
+}
+
+describe('ChurnkeyClient error handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a plain-text error body from the Data API (404)', async () => {
+    mockFetch('Blueprint step not found.', 404)
+    await expect(makeClient().get('/data/blueprints/x/step')).rejects.toThrow('Blueprint step not found.')
+  })
+
+  it('surfaces a 422 validation message verbatim', async () => {
+    mockFetch('Disallowed step update fields: foo', 422)
+    await expect(makeClient().post('/data/blueprints/x/step', { body: {} })).rejects.toThrow(
+      'Disallowed step update fields: foo',
+    )
+  })
+
+  it('surfaces a 403 disabled-account message verbatim', async () => {
+    mockFetch('DSR access is disabled for this account. Please contact support@churnkey.co for assistance.', 403)
+    await expect(makeClient().post('/data/dsr/access', { body: {} })).rejects.toThrow(/disabled for this account/)
+  })
+
+  it('still reads a JSON { message } error body', async () => {
+    mockFetch(JSON.stringify({ message: 'Working copy not found.' }), 404, { 'content-type': 'application/json' })
+    await expect(makeClient().get('/data/blueprints/x')).rejects.toThrow('Working copy not found.')
+  })
+
+  it('keeps the credential hint for 401 regardless of body', async () => {
+    mockFetch('unauthorized', 401)
+    await expect(makeClient().get('/data/blueprints')).rejects.toThrow(/credentials/i)
+  })
+
+  it('gives a typed fallback for an empty 403 body', async () => {
+    mockFetch('', 403)
+    await expect(makeClient().get('/data/blueprints')).rejects.toThrow(/403/)
+  })
+})

--- a/packages/mcp/tests/config.test.ts
+++ b/packages/mcp/tests/config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { loadConfig, loadHttpRequestConfig, loadHttpServerConfig } from '../src/config'
+
+describe('config', () => {
+  it('loads stdio config from environment variables', () => {
+    expect(
+      loadConfig({
+        CHURNKEY_APP_ID: 'app_123',
+        CHURNKEY_API_KEY: 'test_data_key',
+        CHURNKEY_API_URL: 'https://api.example.com/v1/',
+      }),
+    ).toEqual({
+      appId: 'app_123',
+      apiKey: 'test_data_key',
+      baseUrl: 'https://api.example.com/v1',
+    })
+  })
+
+  it('loads HTTP server config with defaults and validates the port', () => {
+    expect(loadHttpServerConfig({})).toEqual({
+      host: '127.0.0.1',
+      port: 3333,
+      path: '/mcp',
+      allowedHosts: undefined,
+    })
+
+    expect(() => loadHttpServerConfig({ CHURNKEY_MCP_PORT: 'nope' })).toThrow(/CHURNKEY_MCP_PORT/)
+    expect(() => loadHttpServerConfig({ CHURNKEY_MCP_PATH: 'mcp' })).toThrow(/CHURNKEY_MCP_PATH/)
+  })
+
+  it('loads HTTP request credentials from headers before env fallback', () => {
+    const headers = new Headers({
+      authorization: 'Bearer live_header_key',
+      'x-ck-app': 'app_header',
+    })
+
+    expect(
+      loadHttpRequestConfig(headers, {
+        CHURNKEY_APP_ID: 'app_env',
+        CHURNKEY_API_KEY: 'env_key',
+      }),
+    ).toEqual({
+      appId: 'app_header',
+      apiKey: 'live_header_key',
+      baseUrl: 'https://api.churnkey.co/v1',
+    })
+  })
+
+  it('prefers x-ck-api-key over Authorization bearer tokens', () => {
+    const headers = new Headers({
+      authorization: 'Bearer bearer_key',
+      'x-ck-api-key': 'header_key',
+    })
+
+    expect(
+      loadHttpRequestConfig(headers, {
+        CHURNKEY_APP_ID: 'app_env',
+        CHURNKEY_API_KEY: 'env_key',
+      }).apiKey,
+    ).toBe('header_key')
+  })
+
+  it('requires an app id and API key for HTTP initialization', () => {
+    expect(() => loadHttpRequestConfig(new Headers(), {})).toThrow(/App ID/)
+    expect(() => loadHttpRequestConfig(new Headers({ 'x-ck-app': 'app_123' }), {})).toThrow(/API key/)
+  })
+})

--- a/packages/mcp/tests/tools/blueprints.test.ts
+++ b/packages/mcp/tests/tools/blueprints.test.ts
@@ -80,6 +80,22 @@ describe('blueprintTools', () => {
     ).toThrow()
   })
 
+  it('validates brandImage against the server image rules', () => {
+    const { tool } = findTool('update_blueprint_draft')
+    const parseBrandImage = (brandImage: string) =>
+      tool.inputSchema.parse({ blueprintId: 'bp_123', updates: { brandImage } })
+
+    // Allowed raster extensions and churnkey.co-hosted images pass.
+    expect(() => parseBrandImage('https://example.com/brand.png')).not.toThrow()
+    expect(() => parseBrandImage('https://cdn.example.com/a/b/logo.webp')).not.toThrow()
+    expect(() => parseBrandImage('https://images.churnkey.co/abc123')).not.toThrow()
+
+    // SVG, other extensions, extension-less URLs, and non-URLs are rejected (matching the server).
+    expect(() => parseBrandImage('https://example.com/logo.svg')).toThrow()
+    expect(() => parseBrandImage('https://example.com/logo')).toThrow()
+    expect(() => parseBrandImage('not-a-url')).toThrow()
+  })
+
   it('routes update_blueprint_step with a compact step patch body', async () => {
     const { tool, post } = findTool('update_blueprint_step')
     const updates = {
@@ -126,6 +142,15 @@ describe('blueprintTools', () => {
         blueprintId: 'bp_123',
         stepGuid: 'step_123',
         updates: { surveyChoices: [{ choiceGuid: 'choice_123', label: 'Nope' }] },
+      }),
+    ).toThrow()
+
+    // Empty-string guids are rejected rather than silently treated as "absent".
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: '',
+        updates: { header: 'New header' },
       }),
     ).toThrow()
   })

--- a/packages/mcp/tests/tools/blueprints.test.ts
+++ b/packages/mcp/tests/tools/blueprints.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChurnkeyClient } from '../../src/client'
+import { blueprintTools } from '../../src/tools/blueprints'
+
+function createMockClient() {
+  const get = vi.fn()
+  const post = vi.fn()
+  return {
+    client: { get, post } as unknown as ChurnkeyClient,
+    get,
+    post,
+  }
+}
+
+function findTool(name: string) {
+  const { client, get, post } = createMockClient()
+  const tool = blueprintTools(client).find((candidate) => candidate.name === name)
+  if (!tool) throw new Error(`Missing tool ${name}`)
+  return { tool, get, post }
+}
+
+describe('blueprintTools', () => {
+  it('routes list_blueprints through the Data API blueprint list endpoint', async () => {
+    const { tool, get } = findTool('list_blueprints')
+
+    await tool.handler({})
+
+    expect(get).toHaveBeenCalledWith('/data/blueprints')
+  })
+
+  it('routes get_blueprint through the Data API blueprint detail endpoint', async () => {
+    const { tool, get } = findTool('get_blueprint')
+
+    await tool.handler({ blueprintId: 'bp_123' })
+
+    expect(get).toHaveBeenCalledWith('/data/blueprints/bp_123')
+  })
+
+  it('routes update_blueprint_draft with only the updates payload in the body', async () => {
+    const { tool, post } = findTool('update_blueprint_draft')
+    const updates = {
+      name: 'Updated flow',
+      primaryColor: '#123456',
+      brandImage: 'https://example.com/brand.png',
+      steps: [{ stepType: 'SURVEY' }],
+      translatedLanguages: ['es'],
+    }
+
+    await tool.handler({ blueprintId: 'bp_123', updates })
+
+    expect(post).toHaveBeenCalledWith('/data/blueprints/bp_123/draft', { body: { updates } })
+  })
+
+  it('requires supported draft update fields', () => {
+    const { tool } = findTool('update_blueprint_draft')
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        updates: {
+          name: 'Updated flow',
+          primaryColor: '#123456',
+          brandImage: 'https://example.com/brand.png',
+          steps: [{ stepType: 'SURVEY' }],
+          translatedLanguages: ['es'],
+        },
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        updates: { brandImage: 'not-a-url' },
+      }),
+    ).toThrow()
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        updates: { liveVersion: true },
+      }),
+    ).toThrow()
+  })
+
+  it('routes publish_blueprint only with the explicit confirmation', async () => {
+    const { tool, post } = findTool('publish_blueprint')
+
+    await tool.handler({ blueprintId: 'bp_123', confirm: 'publish' })
+
+    expect(post).toHaveBeenCalledWith('/data/blueprints/bp_123/publish', { body: { confirm: 'publish' } })
+  })
+
+  it('requires the publish confirmation literal', () => {
+    const { tool } = findTool('publish_blueprint')
+
+    expect(() => tool.inputSchema.parse({ blueprintId: 'bp_123', confirm: 'publish' })).not.toThrow()
+    expect(() => tool.inputSchema.parse({ blueprintId: 'bp_123' })).toThrow()
+    expect(() => tool.inputSchema.parse({ blueprintId: 'bp_123', confirm: 'yes' })).toThrow()
+  })
+})

--- a/packages/mcp/tests/tools/blueprints.test.ts
+++ b/packages/mcp/tests/tools/blueprints.test.ts
@@ -182,4 +182,64 @@ describe('blueprintTools', () => {
     expect(() => tool.inputSchema.parse({ blueprintId: 'bp_123' })).toThrow()
     expect(() => tool.inputSchema.parse({ blueprintId: 'bp_123', confirm: 'yes' })).toThrow()
   })
+
+  it('accepts survey/freeform/confirm behavioral config on update_blueprint_step', () => {
+    const { tool } = findTool('update_blueprint_step')
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: 'step_123',
+        updates: { survey: { randomize: true, minLength: 20 }, confirmConfig: { discountNotice: true } },
+      }),
+    ).not.toThrow()
+    // unknown nested key rejected
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: 'step_123',
+        updates: { survey: { shuffle: true } },
+      }),
+    ).toThrow()
+  })
+
+  it('routes update_blueprint_offer and requires choiceGuid for optionGuid', async () => {
+    const { tool, post } = findTool('update_blueprint_offer')
+
+    await tool.handler({
+      blueprintId: 'bp_123',
+      stepGuid: 'step_1',
+      offerType: 'DISCOUNT',
+      config: { customAmount: 1500, customDuration: 'ONCE' },
+    })
+    expect(post).toHaveBeenCalledWith('/data/blueprints/bp_123/offer', {
+      body: { stepGuid: 'step_1', offerType: 'DISCOUNT', config: { customAmount: 1500, customDuration: 'ONCE' } },
+    })
+
+    await expect(
+      tool.handler({ blueprintId: 'bp_123', stepGuid: 'step_1', optionGuid: 'opt_1', config: {} }),
+    ).rejects.toThrow('optionGuid requires choiceGuid.')
+  })
+
+  it('routes edit_survey_structure with the op body', async () => {
+    const { tool, post } = findTool('edit_survey_structure')
+
+    await tool.handler({ blueprintId: 'bp_123', op: 'add_choice', stepGuid: 'step_1', value: 'Too pricey' })
+    expect(post).toHaveBeenCalledWith('/data/blueprints/bp_123/survey', {
+      body: { op: 'add_choice', stepGuid: 'step_1', value: 'Too pricey' },
+    })
+  })
+
+  it('routes add_blueprint_step and remove_blueprint_step', async () => {
+    const add = findTool('add_blueprint_step')
+    await add.tool.handler({ blueprintId: 'bp_123', place: 'FINAL_OFFER' })
+    expect(add.post).toHaveBeenCalledWith('/data/blueprints/bp_123/step/add', { body: { place: 'FINAL_OFFER' } })
+
+    const remove = findTool('remove_blueprint_step')
+    await remove.tool.handler({ blueprintId: 'bp_123', stepGuid: 'step_9' })
+    expect(remove.post).toHaveBeenCalledWith('/data/blueprints/bp_123/step/remove', { body: { stepGuid: 'step_9' } })
+
+    // place must be a known slot
+    expect(() => add.tool.inputSchema.parse({ blueprintId: 'bp_123', place: 'MIDDLE' })).toThrow()
+  })
 })

--- a/packages/mcp/tests/tools/blueprints.test.ts
+++ b/packages/mcp/tests/tools/blueprints.test.ts
@@ -42,7 +42,6 @@ describe('blueprintTools', () => {
       name: 'Updated flow',
       primaryColor: '#123456',
       brandImage: 'https://example.com/brand.png',
-      steps: [{ stepType: 'SURVEY' }],
       translatedLanguages: ['es'],
     }
 
@@ -61,7 +60,6 @@ describe('blueprintTools', () => {
           name: 'Updated flow',
           primaryColor: '#123456',
           brandImage: 'https://example.com/brand.png',
-          steps: [{ stepType: 'SURVEY' }],
           translatedLanguages: ['es'],
         },
       }),
@@ -77,9 +75,71 @@ describe('blueprintTools', () => {
     expect(() =>
       tool.inputSchema.parse({
         blueprintId: 'bp_123',
-        updates: { liveVersion: true },
+        updates: { steps: [{ stepType: 'SURVEY' }] },
       }),
     ).toThrow()
+  })
+
+  it('routes update_blueprint_step with a compact step patch body', async () => {
+    const { tool, post } = findTool('update_blueprint_step')
+    const updates = {
+      header: 'New header',
+      offer: { description: 'New offer description' },
+      surveyChoices: [{ choiceGuid: 'choice_123', value: 'Too expensive', followupQuestion: 'What price works?' }],
+    }
+
+    await tool.handler({ blueprintId: 'bp_123', stepGuid: 'step_123', updates })
+
+    expect(post).toHaveBeenCalledWith('/data/blueprints/bp_123/step', {
+      body: { stepGuid: 'step_123', stepIndex: undefined, updates },
+    })
+  })
+
+  it('requires one step selector and supported step patch fields', () => {
+    const { tool } = findTool('update_blueprint_step')
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: 'step_123',
+        updates: { header: 'New header', enabled: true },
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        updates: { header: 'New header' },
+      }),
+    ).not.toThrow()
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: 'step_123',
+        updates: { steps: [] },
+      }),
+    ).toThrow()
+
+    expect(() =>
+      tool.inputSchema.parse({
+        blueprintId: 'bp_123',
+        stepGuid: 'step_123',
+        updates: { surveyChoices: [{ choiceGuid: 'choice_123', label: 'Nope' }] },
+      }),
+    ).toThrow()
+  })
+
+  it('requires exactly one step selector before routing update_blueprint_step', async () => {
+    const { tool, post } = findTool('update_blueprint_step')
+
+    await expect(tool.handler({ blueprintId: 'bp_123', updates: { header: 'New header' } })).rejects.toThrow(
+      'Pass exactly one of stepGuid or stepIndex.',
+    )
+    await expect(
+      tool.handler({ blueprintId: 'bp_123', stepGuid: 'step_123', stepIndex: 0, updates: { header: 'New header' } }),
+    ).rejects.toThrow('Pass exactly one of stepGuid or stepIndex.')
+    expect(post).not.toHaveBeenCalled()
   })
 
   it('routes publish_blueprint only with the explicit confirmation', async () => {

--- a/packages/mcp/tests/tools/filters.test.ts
+++ b/packages/mcp/tests/tools/filters.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildQuery } from '../../src/tools/filters'
+
+describe('buildQuery', () => {
+  it('flattens exclusion filters and joins breakdown dimensions', () => {
+    expect(
+      buildQuery({
+        startDate: '2026-01-01',
+        customerEmail: null,
+        limit: 50,
+        skip: 0,
+        not: {
+          saveType: 'ABANDON',
+          canceled: true,
+          response: undefined,
+        },
+        breakdownBy: ['month', 'saveType'],
+      }),
+    ).toEqual({
+      startDate: '2026-01-01',
+      limit: 50,
+      skip: 0,
+      '-saveType': 'ABANDON',
+      '-canceled': true,
+      breakdown: 'month-saveType',
+    })
+  })
+
+  it('omits empty breakdowns', () => {
+    expect(buildQuery({ breakdownBy: [] })).toEqual({})
+  })
+})

--- a/packages/mcp/tests/tools/segments.test.ts
+++ b/packages/mcp/tests/tools/segments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChurnkeyClient } from '../../src/client'
+import { segmentTools } from '../../src/tools/segments'
+
+function findTool(name: string) {
+  const get = vi.fn()
+  const post = vi.fn()
+  const client = { get, post } as unknown as ChurnkeyClient
+  const tool = segmentTools(client).find((candidate) => candidate.name === name)
+  if (!tool) throw new Error(`Missing tool ${name}`)
+  return { tool, get, post }
+}
+
+describe('segmentTools', () => {
+  it('routes list_segments through the Data API segment list endpoint', async () => {
+    const { tool, get } = findTool('list_segments')
+
+    await tool.handler({})
+
+    expect(get).toHaveBeenCalledWith('/data/segments')
+  })
+
+  it('routes reorder_segments with the full confirmed body', async () => {
+    const { tool, post } = findTool('reorder_segments')
+    const args = { segmentIds: ['seg_1', 'seg_2'], confirm: 'reorder_segments' as const }
+
+    await tool.handler(args)
+
+    expect(post).toHaveBeenCalledWith('/data/segments/reorder', { body: args })
+  })
+
+  it('requires non-empty segment IDs and the reorder confirmation literal', () => {
+    const { tool } = findTool('reorder_segments')
+
+    expect(() => tool.inputSchema.parse({ segmentIds: ['seg_1', 'seg_2'], confirm: 'reorder_segments' })).not.toThrow()
+    expect(() => tool.inputSchema.parse({ segmentIds: [], confirm: 'reorder_segments' })).toThrow()
+    expect(() => tool.inputSchema.parse({ segmentIds: ['seg_1'] })).toThrow()
+    expect(() => tool.inputSchema.parse({ segmentIds: ['seg_1'], confirm: 'yes' })).toThrow()
+  })
+})

--- a/packages/mcp/tests/tools/segments.test.ts
+++ b/packages/mcp/tests/tools/segments.test.ts
@@ -37,4 +37,47 @@ describe('segmentTools', () => {
     expect(() => tool.inputSchema.parse({ segmentIds: ['seg_1'] })).toThrow()
     expect(() => tool.inputSchema.parse({ segmentIds: ['seg_1'], confirm: 'yes' })).toThrow()
   })
+
+  it('routes set_segment_enabled with the confirmed body', async () => {
+    const { tool, post } = findTool('set_segment_enabled')
+
+    await tool.handler({ segmentId: 'seg_1', enabled: false, confirm: 'set_segment_enabled' })
+    expect(post).toHaveBeenCalledWith('/data/segments/seg_1/enabled', {
+      body: { enabled: false, confirm: 'set_segment_enabled' },
+    })
+
+    expect(() => tool.inputSchema.parse({ segmentId: 'seg_1', enabled: false })).toThrow()
+    expect(() => tool.inputSchema.parse({ segmentId: 'seg_1', enabled: false, confirm: 'yes' })).toThrow()
+  })
+
+  it('routes update_segment_filter and enforces BETWEEN value length', async () => {
+    const { tool, post } = findTool('update_segment_filter')
+    const filter = [{ attribute: 'PLAN_ID', operand: 'INCLUDES' as const, value: ['price_1'] }]
+
+    await tool.handler({ segmentId: 'seg_1', filter, confirm: 'update_segment_filter' })
+    expect(post).toHaveBeenCalledWith('/data/segments/seg_1/filter', {
+      body: { filter, confirm: 'update_segment_filter' },
+    })
+
+    // BETWEEN needs exactly 2 values
+    expect(() =>
+      tool.inputSchema.parse({
+        segmentId: 'seg_1',
+        filter: [{ attribute: 'AGE', operand: 'BETWEEN', value: [1] }],
+        confirm: 'update_segment_filter',
+      }),
+    ).toThrow()
+    // unsupported operand rejected
+    expect(() =>
+      tool.inputSchema.parse({
+        segmentId: 'seg_1',
+        filter: [{ attribute: 'PLAN_ID', operand: 'EQUAL', value: ['x'] }],
+        confirm: 'update_segment_filter',
+      }),
+    ).toThrow()
+    // empty filter (clear all) is allowed
+    expect(() =>
+      tool.inputSchema.parse({ segmentId: 'seg_1', filter: [], confirm: 'update_segment_filter' }),
+    ).not.toThrow()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.15)(jsdom@25.0.1)
 
   packages/node:
     devDependencies:


### PR DESCRIPTION
## Summary
- adds an opt-in Streamable HTTP transport mode for `@churnkey/mcp` while keeping stdio as the default
- supports session-scoped HTTP transports at `/mcp`, configurable host/port/path, host allow-listing, and opt-in CORS
- accepts Churnkey credentials from env vars or from initialization request headers, including `Authorization: Bearer` for future hosted/OAuth-adjacent auth work
- documents the recommended `mcp.churnkey.co` docs/root and `/mcp` protocol endpoint split

## OAuth foundation
This does not implement OAuth yet. The HTTP request auth boundary is isolated in `loadHttpRequestConfig()`, so the future OAuth task can swap bearer-token validation/resource metadata into that layer without changing MCP tool registration.

## Validation
- `pnpm exec biome check packages/mcp/src/config.ts packages/mcp/src/http.ts packages/mcp/src/bin.ts packages/mcp/src/index.ts packages/mcp/tests/config.test.ts`
- `pnpm --filter @churnkey/mcp typecheck`
- `pnpm --filter @churnkey/mcp test`
- `pnpm --filter @churnkey/mcp build`
- Streamable HTTP SDK client smoke: initialized against `http://127.0.0.1:3341/mcp` and listed 19 tools
- pre-push hook: root `pnpm typecheck` and `pnpm test` passed