### PR TITLE
Add customerAttributes prop

### DIFF
--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -526,6 +526,7 @@ export function TestHarness() {
   const [customerEmail, setCustomerEmail] = usePersistedField('customerEmail')
   const [subscriptionId, setSubscriptionId] = usePersistedField('subscriptionId')
   const [planPriceStr, setPlanPrice] = usePersistedField('planPrice', '2999')
+  const [customerAttributesStr, setCustomerAttributesStr] = usePersistedField('customerAttributes')
   const [apiBase, setApiBase] = usePersistedField('apiBase', 'http://localhost:3000/v1')
   const [scenario, setScenario] = useState<Scenario>('open-source')
   const [mode, setMode] = useState<'live' | 'test'>('test')
@@ -575,6 +576,19 @@ export function TestHarness() {
 
   const customer: DirectCustomer | undefined =
     scenario !== 'open-source' ? { id: customerId || 'cus_test', email: customerEmail || undefined } : undefined
+
+  // Half-typed JSON shouldn't take down the harness — invalid input just
+  // means no attributes are passed.
+  const customerAttributes = useMemo(() => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(customerAttributesStr)
+    } catch {
+      return undefined
+    }
+    const isObject = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    return isObject ? (parsed as Record<string, unknown>) : undefined
+  }, [customerAttributesStr])
 
   const subscriptions: DirectSubscription[] | undefined =
     scenario === 'analytics-full' || scenario === 'token-analytics' || scenario === 'custom-steps'
@@ -718,6 +732,17 @@ export function TestHarness() {
             disabled={!needsAppId}
           />
         </div>
+        <div style={{ marginTop: 8 }}>
+          {/* Drives segment matching in token mode; merge fields and the
+              session record in every mode. */}
+          <Field
+            label="Customer Attributes (JSON)"
+            value={customerAttributesStr}
+            onChange={setCustomerAttributesStr}
+            placeholder='{"isRebateEligible": true}'
+            disabled={!needsCustomer}
+          />
+        </div>
       </fieldset>
 
       {/* Scenario picker */}
@@ -852,6 +877,7 @@ export function TestHarness() {
           appId={needsAppId && appId ? appId : undefined}
           customer={customer}
           subscriptions={subscriptions}
+          customerAttributes={customerAttributes}
           session={token}
           mode={mode}
           apiBaseUrl={needsAppId ? apiBase : undefined}

--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -739,7 +739,7 @@ export function TestHarness() {
             label="Customer Attributes (JSON)"
             value={customerAttributesStr}
             onChange={setCustomerAttributesStr}
-            placeholder='{"isRebateEligible": true}'
+            placeholder='{"videosCreated": 28}'
             disabled={!needsCustomer}
           />
         </div>

--- a/packages/react/src/core/api.ts
+++ b/packages/react/src/core/api.ts
@@ -152,8 +152,15 @@ export class ChurnkeyApi {
     return res
   }
 
-  async fetchConfig(): Promise<SdkConfig> {
-    const res = await this.request(this.orgUrl('cancel-flow/config'))
+  // customAttributes feed server-side segment matching when the blueprint is
+  // picked. The body must not also carry a Direct `customer` — that tells the
+  // server to skip the provider lookup, and segments should match against the
+  // real provider customer plus this attribute layer.
+  async fetchConfig(customAttributes?: Record<string, unknown>): Promise<SdkConfig> {
+    const res = await this.request(
+      this.orgUrl('cancel-flow/config'),
+      customAttributes ? { customAttributes } : undefined,
+    )
     return (await res.json()) as SdkConfig
   }
 

--- a/packages/react/src/core/machine.ts
+++ b/packages/react/src/core/machine.ts
@@ -211,6 +211,7 @@ export class CancelFlowMachine {
   private analyticsClient: AnalyticsClient | null = null
   private directCustomer: DirectCustomer | null = null
   private directSubscriptions: DirectSubscription[] | null = null
+  private customerAttributes: Record<string, unknown> | null = null
   private creds: SessionCredentials | null = null
   private config: SdkConfig | null = null
   private blueprintId: string | null = null
@@ -231,6 +232,7 @@ export class CancelFlowMachine {
     // every callback by name without a separate copy.
     this.callbacks = config
     if (config.mode) this.configMode = config.mode
+    if (config.customerAttributes) this.customerAttributes = config.customerAttributes
     if (config.appId && config.customer) {
       this.analyticsClient = new AnalyticsClient(config.appId, config.apiBaseUrl)
       this.directCustomer = config.customer
@@ -243,7 +245,7 @@ export class CancelFlowMachine {
     if (config.session) {
       if (config.steps) this.localSteps = config.steps
     } else if (config.steps) {
-      const merged = applyMergeFieldsToSteps(config.steps, this.directCustomer)
+      const merged = applyMergeFieldsToSteps(config.steps, this.directCustomer, this.customerAttributes)
       this.graph = buildStepGraph(merged, defaultOfferCopy)
     }
 
@@ -437,7 +439,7 @@ export class CancelFlowMachine {
     this.blueprintId = result.blueprintId
 
     const merged = this.localSteps ? mergeLocalSteps(result.steps, this.localSteps) : result.steps
-    const steps = applyMergeFieldsToSteps(merged, config.customer ?? null)
+    const steps = applyMergeFieldsToSteps(merged, config.customer ?? null, this.customerAttributes)
     this.graph = buildStepGraph(steps, defaultOfferCopy)
 
     this.state = this.buildInitialState(config.customer ?? null, config.subscriptions ?? [])
@@ -636,12 +638,17 @@ export class CancelFlowMachine {
     const direct = this.directCustomer
       ? directDataToSessionCustomer(this.directCustomer, this.directSubscriptions ?? undefined)
       : undefined
+    // The consumer's attribute layer wins key conflicts with customer.metadata,
+    // matching merge-field precedence and the embed's session shape.
+    const customAttributes = this.customerAttributes
+      ? { ...direct?.customAttributes, ...this.customerAttributes }
+      : direct?.customAttributes
     // Token identifies the customer authoritatively; direct data fills in
     // extras (email, plan, metadata) but never overrides id/subscriptionId.
     if (this.creds) {
-      return { ...direct, id: this.creds.customerId, subscriptionId: this.creds.subscriptionId }
+      return { ...direct, customAttributes, id: this.creds.customerId, subscriptionId: this.creds.subscriptionId }
     }
-    return direct
+    return direct ? { ...direct, customAttributes } : undefined
   }
 
   private buildBasePayload(): SessionPayload {

--- a/packages/react/src/core/merge-fields.ts
+++ b/packages/react/src/core/merge-fields.ts
@@ -23,24 +23,34 @@ const MERGE_FIELD_PATTERN = /{{([a-zA-Z0-9_.]+)\|([^}]*)}}/g
 /**
  * Build the attribute map merge fields are resolved against. Sourced from
  * Direct.Customer fields: name (with `.FIRST`/`.LAST` variants), email, and
- * metadata. Values that aren't strings are coerced — dashboards emit merge
- * fields into HTML, and HTML only speaks strings.
+ * metadata, then the consumer's `customerAttributes` layer, which wins key
+ * conflicts (same precedence as the embed). Values that aren't strings are
+ * coerced — dashboards emit merge fields into HTML, and HTML only speaks
+ * strings.
  */
-export function buildMergeAttrs(customer: DirectCustomer | null | undefined): MergeAttrs {
-  if (!customer) return {}
+export function buildMergeAttrs(
+  customer: DirectCustomer | null | undefined,
+  customerAttributes?: Record<string, unknown> | null,
+): MergeAttrs {
   const attrs: MergeAttrs = {}
 
-  // Build full name from Direct.Customer's separate first/last name fields.
-  const first = customer.name
-  const last = customer.lastName
-  const fullName = [first, last].filter(Boolean).join(' ') || undefined
-  if (fullName) attrs.CUSTOMER_NAME = fullName
-  if (first) attrs['CUSTOMER_NAME.FIRST'] = first
-  if (last) attrs['CUSTOMER_NAME.LAST'] = last
+  if (customer) {
+    // Build full name from Direct.Customer's separate first/last name fields.
+    const first = customer.name
+    const last = customer.lastName
+    const fullName = [first, last].filter(Boolean).join(' ') || undefined
+    if (fullName) attrs.CUSTOMER_NAME = fullName
+    if (first) attrs['CUSTOMER_NAME.FIRST'] = first
+    if (last) attrs['CUSTOMER_NAME.LAST'] = last
 
-  if (customer.email) attrs.CUSTOMER_EMAIL = customer.email
+    if (customer.email) attrs.CUSTOMER_EMAIL = customer.email
 
-  for (const [key, value] of Object.entries(customer.metadata ?? {})) {
+    for (const [key, value] of Object.entries(customer.metadata ?? {})) {
+      if (value != null) attrs[key] = String(value)
+    }
+  }
+
+  for (const [key, value] of Object.entries(customerAttributes ?? {})) {
     if (value != null) attrs[key] = String(value)
   }
 
@@ -63,8 +73,12 @@ export function applyMergeFields(text: string, attrs: MergeAttrs): string {
  * so the runtime carries already-resolved copy — components stay unaware of
  * merge fields entirely.
  */
-export function applyMergeFieldsToSteps(steps: Step[], customer: DirectCustomer | null | undefined): Step[] {
-  const attrs = buildMergeAttrs(customer)
+export function applyMergeFieldsToSteps(
+  steps: Step[],
+  customer: DirectCustomer | null | undefined,
+  customerAttributes?: Record<string, unknown> | null,
+): Step[] {
+  const attrs = buildMergeAttrs(customer, customerAttributes)
   return steps.map((step) => mergeStep(step, attrs))
 }
 

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -632,8 +632,8 @@ export interface FlowConfig extends FlowCallbacks {
   customer?: DirectCustomer
   subscriptions?: DirectSubscription[]
   /**
-   * Client-side attribute layer on top of provider data, e.g. entitlements
-   * only the host app knows (`{ isRebateEligible: true }`). In token mode
+   * Client-side attribute layer on top of provider data, e.g. usage counts
+   * or entitlements only the host app knows (`{ videosCreated: 28 }`). In token mode
    * they're sent with the config request so segments can match on them when
    * picking the blueprint. In every mode they resolve as merge fields and
    * are recorded on the session, taking precedence over `customer.metadata`

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -631,6 +631,15 @@ export interface FlowConfig extends FlowCallbacks {
   appId?: string
   customer?: DirectCustomer
   subscriptions?: DirectSubscription[]
+  /**
+   * Client-side attribute layer on top of provider data, e.g. entitlements
+   * only the host app knows (`{ isRebateEligible: true }`). In token mode
+   * they're sent with the config request so segments can match on them when
+   * picking the blueprint. In every mode they resolve as merge fields and
+   * are recorded on the session, taking precedence over `customer.metadata`
+   * keys. Same role as the embed's `customerAttributes`.
+   */
+  customerAttributes?: Record<string, unknown>
   session?: string
   apiBaseUrl?: string
   steps?: Step[]
@@ -683,6 +692,8 @@ export interface CancelFlowProps extends FlowCallbacks {
   appId?: string
   customer?: DirectCustomer
   subscriptions?: DirectSubscription[]
+  /** See FlowConfig.customerAttributes. */
+  customerAttributes?: Record<string, unknown>
   session?: string
   steps?: Step[]
   apiBaseUrl?: string

--- a/packages/react/src/headless/use-cancel-flow-machine.ts
+++ b/packages/react/src/headless/use-cancel-flow-machine.ts
@@ -71,7 +71,10 @@ export function useCancelFlowMachine(config: FlowConfig): CancelFlowMachineHandl
     const creds = decodeSessionToken(config.session)
     const api = new ChurnkeyApi(creds, config.apiBaseUrl)
     api
-      .fetchConfig()
+      // Read through the ref, not the closure: an inline `customerAttributes`
+      // object literal would otherwise join the dep list and re-fetch (and
+      // reset the flow) on every render.
+      .fetchConfig(callbacksRef.current.customerAttributes)
       .then((sdkConfig) => {
         if (cancelled) return
         machine.initializeFromConfig(sdkConfig, api, creds)

--- a/packages/react/tests/core/api.test.ts
+++ b/packages/react/tests/core/api.test.ts
@@ -78,6 +78,22 @@ describe('ChurnkeyApi action paths', () => {
     expect(calledPath(spy)).toBe('https://api.test/v1/api/orgs/app_test/cancel-flow/config')
   })
 
+  it('fetchConfig sends no body without customAttributes', async () => {
+    // Presence of a `customer` body makes the server skip the provider
+    // lookup, so the default request must stay body-less.
+    const spy = spyFetch()
+    const api = new ChurnkeyApi(creds, 'https://api.test/v1')
+    await api.fetchConfig()
+    expect(spy.mock.calls[0][1]?.body).toBeUndefined()
+  })
+
+  it('fetchConfig sends customAttributes as the request body for segment matching', async () => {
+    const spy = spyFetch()
+    const api = new ChurnkeyApi(creds, 'https://api.test/v1')
+    await api.fetchConfig({ isRebateEligible: true })
+    expect(calledBody(spy)).toEqual({ customAttributes: { isRebateEligible: true } })
+  })
+
   it('createSession hits /api/sessions/sdk', async () => {
     const spy = spyFetch()
     const api = new ChurnkeyApi(creds, 'https://api.test/v1')

--- a/packages/react/tests/core/api.test.ts
+++ b/packages/react/tests/core/api.test.ts
@@ -90,8 +90,8 @@ describe('ChurnkeyApi action paths', () => {
   it('fetchConfig sends customAttributes as the request body for segment matching', async () => {
     const spy = spyFetch()
     const api = new ChurnkeyApi(creds, 'https://api.test/v1')
-    await api.fetchConfig({ isRebateEligible: true })
-    expect(calledBody(spy)).toEqual({ customAttributes: { isRebateEligible: true } })
+    await api.fetchConfig({ videosCreated: 28 })
+    expect(calledBody(spy)).toEqual({ customAttributes: { videosCreated: 28 } })
   })
 
   it('createSession hits /api/sessions/sdk', async () => {

--- a/packages/react/tests/core/machine.test.ts
+++ b/packages/react/tests/core/machine.test.ts
@@ -1667,6 +1667,65 @@ describe('CancelFlowMachine', () => {
       expect(customer.planPrice).toBe(4999)
       expect(customer.currency).toBe('usd')
     })
+
+    // The customerAttributes layer is recorded on the session like the
+    // embed's, winning key conflicts with customer.metadata.
+    it('records customerAttributes on the session customer in token mode', async () => {
+      const sessions: any[] = []
+      const mockApi = {
+        createSession: vi.fn(async (payload: any) => {
+          sessions.push(payload)
+        }),
+        cancelSubscription: vi.fn(async () => {}),
+      }
+      const machine = new CancelFlowMachine({
+        session: 'ck_placeholder',
+        appId: 'app_test',
+        customer: { id: 'cus_123', metadata: { plan: 'pro', seats: 4 } },
+        customerAttributes: { plan: 'enterprise', isRebateEligible: true },
+      })
+      machine.initializeFromConfig(sdkConfig({ steps: [{ type: 'confirm', guid: 'c1' }] }), mockApi as any, {
+        appId: 'app_test',
+        customerId: 'cus_123',
+        authHash: 'h',
+        mode: 'live' as const,
+        issuedAt: 0,
+      })
+      await machine.cancel()
+
+      expect(sessions).toHaveLength(1)
+      expect(sessions[0].customer.customAttributes).toEqual({
+        plan: 'enterprise',
+        seats: 4,
+        isRebateEligible: true,
+      })
+    })
+
+    it('records customerAttributes on the session customer without a customer prop', async () => {
+      const sessions: any[] = []
+      const mockApi = {
+        createSession: vi.fn(async (payload: any) => {
+          sessions.push(payload)
+        }),
+        cancelSubscription: vi.fn(async () => {}),
+      }
+      const machine = new CancelFlowMachine({
+        session: 'ck_placeholder',
+        customerAttributes: { isRebateEligible: true },
+      })
+      machine.initializeFromConfig(sdkConfig({ steps: [{ type: 'confirm', guid: 'c1' }] }), mockApi as any, {
+        appId: 'app_test',
+        customerId: 'cus_123',
+        authHash: 'h',
+        mode: 'live' as const,
+        issuedAt: 0,
+      })
+      await machine.cancel()
+
+      expect(sessions).toHaveLength(1)
+      expect(sessions[0].customer.id).toBe('cus_123')
+      expect(sessions[0].customer.customAttributes).toEqual({ isRebateEligible: true })
+    })
   })
 
   describe('customer exposure', () => {

--- a/packages/react/tests/core/machine.test.ts
+++ b/packages/react/tests/core/machine.test.ts
@@ -1682,7 +1682,7 @@ describe('CancelFlowMachine', () => {
         session: 'ck_placeholder',
         appId: 'app_test',
         customer: { id: 'cus_123', metadata: { plan: 'pro', seats: 4 } },
-        customerAttributes: { plan: 'enterprise', isRebateEligible: true },
+        customerAttributes: { plan: 'enterprise', videosCreated: 28 },
       })
       machine.initializeFromConfig(sdkConfig({ steps: [{ type: 'confirm', guid: 'c1' }] }), mockApi as any, {
         appId: 'app_test',
@@ -1697,7 +1697,7 @@ describe('CancelFlowMachine', () => {
       expect(sessions[0].customer.customAttributes).toEqual({
         plan: 'enterprise',
         seats: 4,
-        isRebateEligible: true,
+        videosCreated: 28,
       })
     })
 
@@ -1711,7 +1711,7 @@ describe('CancelFlowMachine', () => {
       }
       const machine = new CancelFlowMachine({
         session: 'ck_placeholder',
-        customerAttributes: { isRebateEligible: true },
+        customerAttributes: { videosCreated: 28 },
       })
       machine.initializeFromConfig(sdkConfig({ steps: [{ type: 'confirm', guid: 'c1' }] }), mockApi as any, {
         appId: 'app_test',
@@ -1724,7 +1724,7 @@ describe('CancelFlowMachine', () => {
 
       expect(sessions).toHaveLength(1)
       expect(sessions[0].customer.id).toBe('cus_123')
-      expect(sessions[0].customer.customAttributes).toEqual({ isRebateEligible: true })
+      expect(sessions[0].customer.customAttributes).toEqual({ videosCreated: 28 })
     })
   })
 

--- a/packages/react/tests/core/merge-fields.test.ts
+++ b/packages/react/tests/core/merge-fields.test.ts
@@ -77,11 +77,11 @@ describe('buildMergeAttrs', () => {
   it('layers customerAttributes over metadata, winning key conflicts', () => {
     const attrs = buildMergeAttrs(
       { id: 'cus_1', metadata: { PLAN: 'pro', TEAM_SIZE: 12 } },
-      { PLAN: 'enterprise', isRebateEligible: true },
+      { PLAN: 'enterprise', videosCreated: 28 },
     )
     expect(attrs.PLAN).toBe('enterprise')
     expect(attrs.TEAM_SIZE).toBe('12')
-    expect(attrs.isRebateEligible).toBe('true')
+    expect(attrs.videosCreated).toBe('28')
   })
 
   it('resolves customerAttributes without a customer', () => {

--- a/packages/react/tests/core/merge-fields.test.ts
+++ b/packages/react/tests/core/merge-fields.test.ts
@@ -73,6 +73,21 @@ describe('buildMergeAttrs', () => {
     expect(attrs.PLAN).toBe('pro')
     expect(attrs.TEAM_SIZE).toBe('12')
   })
+
+  it('layers customerAttributes over metadata, winning key conflicts', () => {
+    const attrs = buildMergeAttrs(
+      { id: 'cus_1', metadata: { PLAN: 'pro', TEAM_SIZE: 12 } },
+      { PLAN: 'enterprise', isRebateEligible: true },
+    )
+    expect(attrs.PLAN).toBe('enterprise')
+    expect(attrs.TEAM_SIZE).toBe('12')
+    expect(attrs.isRebateEligible).toBe('true')
+  })
+
+  it('resolves customerAttributes without a customer', () => {
+    const attrs = buildMergeAttrs(null, { PLAN: 'pro' })
+    expect(attrs.PLAN).toBe('pro')
+  })
 })
 
 describe('applyMergeFieldsToSteps', () => {

--- a/packages/react/tests/headless/use-cancel-flow.test.tsx
+++ b/packages/react/tests/headless/use-cancel-flow.test.tsx
@@ -80,4 +80,19 @@ describe('useCancelFlow', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('sends customerAttributes in the config request body', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => goodResponse } as Response)
+
+    await act(async () => {
+      renderHook(() => useCancelFlow({ session: TOKEN, customerAttributes: { isRebateEligible: true } }))
+    })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/cancel-flow/config')
+    expect(JSON.parse(init.body)).toEqual({ customAttributes: { isRebateEligible: true } })
+  })
 })

--- a/packages/react/tests/headless/use-cancel-flow.test.tsx
+++ b/packages/react/tests/headless/use-cancel-flow.test.tsx
@@ -85,7 +85,7 @@ describe('useCancelFlow', () => {
     fetchMock.mockResolvedValue({ ok: true, json: async () => goodResponse } as Response)
 
     await act(async () => {
-      renderHook(() => useCancelFlow({ session: TOKEN, customerAttributes: { isRebateEligible: true } }))
+      renderHook(() => useCancelFlow({ session: TOKEN, customerAttributes: { videosCreated: 28 } }))
     })
 
     await waitFor(() => {
@@ -93,6 +93,6 @@ describe('useCancelFlow', () => {
     })
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/cancel-flow/config')
-    expect(JSON.parse(init.body)).toEqual({ customAttributes: { isRebateEligible: true } })
+    expect(JSON.parse(init.body)).toEqual({ customAttributes: { videosCreated: 28 } })
   })
 })


### PR DESCRIPTION
## Overview

New top-level `customerAttributes` prop on `<CancelFlow>` / `useCancelFlow`:

```tsx
<CancelFlow
  session={token}
  customerAttributes={{ favoriteAnimal: 'penguin' }}
/>
```

- **Segmentation (connected mode):** `fetchConfig` posts `{ customAttributes }`. Deliberately not piggybacked on `customer.metadata` — a Direct `customer` body tells the server to skip the provider lookup, and this needs the real provider customer plus the attribute layer. No prop → no body, byte-identical request to today.
- **Merge fields:** keys resolve in dashboard copy, winning conflicts with `customer.metadata` (embed precedence).
- **Session record:** merged into the session customer's `customAttributes`, same precedence.

The hook reads the prop through the existing callbacks ref at fetch time; an inline object literal in the dep list would re-fetch and reset the flow every render.

Playground gets a persisted Customer Attributes (JSON) field to exercise this against a local API.