### PR TITLE
Support Stripe Sandbox mode

### DIFF
--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -8,6 +8,7 @@ import type {
   CustomStepProps,
   DirectCustomer,
   DirectSubscription,
+  Mode,
   Step,
 } from '@churnkey/react/core'
 
@@ -529,7 +530,7 @@ export function TestHarness() {
   const [customerAttributesStr, setCustomerAttributesStr] = usePersistedField('customerAttributes')
   const [apiBase, setApiBase] = usePersistedField('apiBase', 'http://localhost:3000/v1')
   const [scenario, setScenario] = useState<Scenario>('open-source')
-  const [mode, setMode] = useState<'live' | 'test'>('test')
+  const [mode, setMode] = useState<Mode>('test')
   const [open, setOpen] = useState(false)
   const [colorScheme, setColorScheme] = useState<'light' | 'dark' | 'auto'>('light')
   const logRef = useRef<HTMLDivElement>(null)
@@ -783,7 +784,7 @@ export function TestHarness() {
         <fieldset style={{ border: '1px solid #e5e7eb', borderRadius: 8, padding: 16, marginBottom: 16 }}>
           <legend style={{ fontSize: 13, fontWeight: 600, color: '#374151', padding: '0 4px' }}>Session mode</legend>
           <div style={{ display: 'flex', gap: 6 }}>
-            {(['test', 'live'] as const).map((m) => (
+            {(['test', 'sandbox', 'live'] as const).map((m) => (
               <Pill key={m} label={m} selected={mode === m} onClick={() => setMode(m)} />
             ))}
           </div>

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect breaking changes in minor versions while we're pre-1.0.
 
+## 0.2.0 — 2026-06-10
+
+### Added
+
+- `mode: 'sandbox'` on `createToken`, for orgs connected to a [Stripe Sandbox](https://docs.stripe.com/sandboxes) rather than classic test mode. Pair with `@churnkey/react` 0.6.0 or later — earlier versions of the react package treat unrecognized modes as `'live'`.
+
 ## 0.1.0 — 2026-05-01
 
 First public release.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -48,7 +48,7 @@ const token = ck.createToken({
 })
 ```
 
-## Test mode
+## Test and sandbox mode
 
 Pass `mode: 'test'` to segregate staging or QA sessions from live analytics. Defaults to `'live'`.
 
@@ -58,6 +58,8 @@ const token = ck.createToken({
   mode: process.env.NODE_ENV === 'production' ? 'live' : 'test',
 })
 ```
+
+If your org is connected to a [Stripe Sandbox](https://docs.stripe.com/sandboxes) rather than classic test mode, pass `mode: 'sandbox'` instead. Sandboxes live under a separate Stripe account ID with their own credentials, and Churnkey routes billing actions accordingly.
 
 ## Using the hosted embed instead
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Server-side SDK for Churnkey. Generate session tokens for use with @churnkey/react.",
   "license": "MIT",
   "repository": {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,7 +3,7 @@ import type { ChurnkeyConfig, CreateTokenParams, Mode, TokenPayload } from './ty
 
 export type { ChurnkeyConfig, CreateTokenParams, Mode, TokenPayload }
 
-export const VERSION = '0.1.0'
+export const VERSION = '0.2.0'
 
 export class Churnkey {
   private appId: string

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -3,12 +3,16 @@ export interface ChurnkeyConfig {
   apiKey: string
 }
 
-export type Mode = 'live' | 'test'
+export type Mode = 'live' | 'test' | 'sandbox'
 
 export interface CreateTokenParams {
   customerId: string
   subscriptionId?: string
-  /** Defaults to 'live'. Use 'test' to segregate staging sessions in analytics. */
+  /**
+   * Defaults to 'live'. Use 'test' to segregate staging sessions in analytics,
+   * or 'sandbox' when the org is connected to a Stripe Sandbox (sandboxes have
+   * their own account ID and credentials, unlike classic test mode).
+   */
   mode?: Mode
 }
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect breaking changes in minor versions while we're pre-1.0.
 
+## 0.6.0 — 2026-06-10
+
+### Added
+
+- **Stripe Sandbox support.** `mode` accepts `'sandbox'` on `<CancelFlow>`, `useCancelFlow`, and session tokens. [Sandboxes](https://docs.stripe.com/sandboxes) supersede Stripe's classic test mode and live under a separate Stripe account ID with their own credentials — pass `'sandbox'` when your Churnkey org is connected to one, so server-side billing actions (discounts, pauses, cancels) run against the sandbox. Sessions record as `SANDBOX`.
+
+### Changed
+
+- `decodeSessionToken` throws on an unrecognized mode instead of treating it as `'live'`. A missing mode still defaults to `'live'`. The old coercion meant a token signed with a mode this package didn't know about would run the flow against live billing — it now fails loudly instead. If you mint tokens with `@churnkey/node`, upgrade both packages together.
+
 ## 0.5.0 — 2026-06-10
 
 ### Added

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -224,7 +224,7 @@ To keep staging traffic out of your production analytics, pass `mode="test"`:
 />
 ```
 
-Defaults to `'live'`. In token mode, the token's mode takes precedence — it's server-signed and can't be overridden client-side.
+Defaults to `'live'`. If your org is connected to a [Stripe Sandbox](https://docs.stripe.com/sandboxes) rather than classic test mode, pass `mode="sandbox"` instead so server-side billing actions use your sandbox credentials. In token mode, the token's mode takes precedence — it's server-signed and can't be overridden client-side.
 
 ## Let Churnkey handle billing
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Production-ready cancel flow for React. Drop-in component, headless hook, or full customization. Works standalone or with Churnkey for AI-powered retention.",
   "license": "MIT",
   "repository": {

--- a/packages/react/src/core/api.ts
+++ b/packages/react/src/core/api.ts
@@ -1,6 +1,6 @@
 import type { SdkConfig } from './api-types'
 import type { SessionCredentials } from './token'
-import type { DirectCustomer, DirectSubscription } from './types'
+import type { DirectCustomer, DirectSubscription, Mode } from './types'
 
 const DEFAULT_BASE_URL = 'https://api.churnkey.co/v1'
 
@@ -19,7 +19,19 @@ export type ApiOfferType =
 export type ApiPauseInterval = 'MONTH' | 'WEEK'
 export type ApiCouponType = 'PERCENT' | 'AMOUNT'
 export type ApiBillingInterval = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'
-export type ApiMode = 'LIVE' | 'TEST'
+export type ApiMode = 'LIVE' | 'TEST' | 'SANDBOX'
+
+// Exhaustive switch so a new Mode member without a wire mapping fails to compile.
+export function toApiMode(mode: Mode): ApiMode {
+  switch (mode) {
+    case 'live':
+      return 'LIVE'
+    case 'test':
+      return 'TEST'
+    case 'sandbox':
+      return 'SANDBOX'
+  }
+}
 
 export interface StepViewed {
   stepType: ApiStepType

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -50,6 +50,7 @@ export type {
   FlowConfig,
   FlowState,
   ModalProps,
+  Mode,
   OfferClassNames,
   OfferConfig,
   OfferCopy,

--- a/packages/react/src/core/machine.ts
+++ b/packages/react/src/core/machine.ts
@@ -8,7 +8,7 @@ import type {
   SessionPayload,
   StepViewed,
 } from './api'
-import { AnalyticsClient, directDataToSessionCustomer } from './api'
+import { AnalyticsClient, directDataToSessionCustomer, toApiMode } from './api'
 import type { SdkConfig } from './api-types'
 import { applyMergeFieldsToSteps } from './merge-fields'
 import { buildStepGraph, type ResolvedStep, type StepGraph } from './step-graph'
@@ -23,6 +23,7 @@ import type {
   FlowCallbacks,
   FlowConfig,
   FlowState,
+  Mode,
   OfferDecision,
   ReasonConfig,
   Step,
@@ -219,7 +220,7 @@ export class CancelFlowMachine {
   private stepsViewed: StepViewed[] = []
   private presentedOffers: PresentedOffer[] = []
   private customStepResults: Record<string, unknown> = {}
-  private configMode: 'live' | 'test' = 'live'
+  private configMode: Mode = 'live'
   private stepEnteredAt: number = Date.now()
   private aborted = false
   // Visited-step stack. `back` pops this so it lands on the actually-seen
@@ -670,7 +671,7 @@ export class CancelFlowMachine {
       stepsViewed: this.stepsViewed,
       customStepResults: Object.keys(this.customStepResults).length > 0 ? this.customStepResults : undefined,
       // Token's signed mode wins — the client can't override it.
-      mode: (this.creds?.mode ?? this.configMode) === 'test' ? 'TEST' : 'LIVE',
+      mode: toApiMode(this.creds?.mode ?? this.configMode),
       provider: this.isTokenMode() ? undefined : 'sdk-react',
       embedVersion: 'sdk-react',
     }

--- a/packages/react/src/core/token.ts
+++ b/packages/react/src/core/token.ts
@@ -1,10 +1,16 @@
+import { MODES, type Mode } from './types'
+
 export interface SessionCredentials {
   appId: string
   customerId: string
   subscriptionId?: string
   authHash: string
-  mode: 'live' | 'test'
+  mode: Mode
   issuedAt: number
+}
+
+function isMode(value: unknown): value is Mode {
+  return MODES.includes(value as Mode)
 }
 
 /** Decode a session token created by `@churnkey/node`. */
@@ -41,13 +47,20 @@ export function decodeSessionToken(token: string): SessionCredentials {
   if (typeof payload.h !== 'string' || !payload.h) {
     throw new Error('Invalid token: missing authHash')
   }
+  // `m` is optional and defaults to 'live'. An unrecognized value is rejected
+  // rather than coerced — coercing would point test or sandbox traffic at
+  // live billing data.
+  const mode = payload.m === undefined ? 'live' : payload.m
+  if (!isMode(mode)) {
+    throw new Error(`Invalid token: unknown mode "${String(payload.m)}"`)
+  }
 
   return {
     appId: payload.a,
     customerId: payload.c,
     subscriptionId: typeof payload.s === 'string' ? payload.s : undefined,
     authHash: payload.h,
-    mode: payload.m === 'test' ? 'test' : 'live',
+    mode,
     issuedAt: typeof payload.t === 'number' ? payload.t : 0,
   }
 }

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -627,6 +627,16 @@ export interface FlowState {
 
 // ─── Flow config ─────────────────────────────────────────────────────────────
 
+export const MODES = ['live', 'test', 'sandbox'] as const
+
+/**
+ * Environment a session runs against. `'test'` and `'sandbox'` both keep
+ * sessions out of live analytics; `'sandbox'` additionally routes server-side
+ * billing actions to the org's Stripe Sandbox credentials, which live under a
+ * separate Stripe account ID from live/test mode.
+ */
+export type Mode = (typeof MODES)[number]
+
 export interface FlowConfig extends FlowCallbacks {
   appId?: string
   customer?: DirectCustomer
@@ -644,12 +654,13 @@ export interface FlowConfig extends FlowCallbacks {
   apiBaseUrl?: string
   steps?: Step[]
   /**
-   * Tags the session as live or test. Use `'test'` from staging so your
-   * dashboard can filter out non-production traffic. Defaults to `'live'`.
+   * Tags the session as live, test, or sandbox. Use `'test'` from staging so
+   * your dashboard can filter out non-production traffic, or `'sandbox'` when
+   * the org is connected to a Stripe Sandbox. Defaults to `'live'`.
    * In token mode the mode is encoded in the signed token and overrides
    * this field.
    */
-  mode?: 'live' | 'test'
+  mode?: Mode
 }
 
 type OfferCallback = (offer: AcceptedOffer, customer: DirectCustomer | null) => Promise<void> | void
@@ -698,7 +709,7 @@ export interface CancelFlowProps extends FlowCallbacks {
   steps?: Step[]
   apiBaseUrl?: string
   /** See FlowConfig.mode. Ignored in token mode (the token is authoritative). */
-  mode?: 'live' | 'test'
+  mode?: Mode
   appearance?: Appearance
   classNames?: StructuralClassNames
   components?: Partial<ComponentOverrides>

--- a/packages/react/tests/core/api.test.ts
+++ b/packages/react/tests/core/api.test.ts
@@ -113,6 +113,14 @@ describe('ChurnkeyApi action paths', () => {
     expect(headers['x-ck-subscription']).toBe('sub_456')
   })
 
+  it('sends x-ck-mode sandbox for sandbox credentials', async () => {
+    const spy = spyFetch()
+    const api = new ChurnkeyApi({ ...creds, mode: 'sandbox' }, 'https://api.test/v1')
+    await api.pause({ duration: 1, interval: 'month' })
+    const headers = spy.mock.calls[0][1]?.headers as Record<string, string>
+    expect(headers['x-ck-mode']).toBe('sandbox')
+  })
+
   it('throws on non-2xx response with status in message', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not found', { status: 404 }))
     const api = new ChurnkeyApi(creds, 'https://api.test/v1')

--- a/packages/react/tests/core/machine.test.ts
+++ b/packages/react/tests/core/machine.test.ts
@@ -1526,6 +1526,44 @@ describe('CancelFlowMachine', () => {
       fetchSpy.mockRestore()
     })
 
+    it('honors mode="sandbox" on analytics-mode sessions', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
+      const machine = new CancelFlowMachine({
+        appId: 'app_test',
+        customer: { id: 'cus_123' },
+        mode: 'sandbox',
+        steps: [{ type: 'survey' as const, reasons: [{ id: 'a', label: 'A' }] }, { type: 'confirm' as const }],
+      })
+      machine.selectReason('a')
+      machine.next()
+      await machine.cancel()
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string)
+      expect(body.mode).toBe('SANDBOX')
+      fetchSpy.mockRestore()
+    })
+
+    it('records SANDBOX when the token is signed with sandbox mode', async () => {
+      const sessions: any[] = []
+      const mockApi = {
+        createSession: vi.fn(async (payload: any) => {
+          sessions.push(payload)
+        }),
+        cancelSubscription: vi.fn(async () => {}),
+      }
+      const machine = new CancelFlowMachine({ session: 'ck_placeholder' })
+      machine.initializeFromConfig(sdkConfig({ steps: [{ type: 'confirm', guid: 'c1' }] }), mockApi as any, {
+        appId: 'a',
+        customerId: 'c',
+        authHash: 'h',
+        mode: 'sandbox' as const,
+        issuedAt: 0,
+      })
+      await machine.cancel()
+
+      expect(sessions[0].mode).toBe('SANDBOX')
+    })
+
     it('token mode overrides FlowConfig.mode (signed token is authoritative)', async () => {
       const sessions: any[] = []
       const mockApi = {

--- a/packages/react/tests/core/token.test.ts
+++ b/packages/react/tests/core/token.test.ts
@@ -37,8 +37,8 @@ describe('decodeSessionToken', () => {
     expect(creds.subscriptionId).toBeUndefined()
   })
 
-  it('defaults mode to live when not "test"', () => {
-    const token = createToken({ ...validPayload, m: 'anything' })
+  it('defaults mode to live when m is absent', () => {
+    const token = createToken({ a: 'app_1', c: 'cus_1', h: 'hash1', t: 0 })
     const creds = decodeSessionToken(token)
 
     expect(creds.mode).toBe('live')
@@ -49,6 +49,18 @@ describe('decodeSessionToken', () => {
     const creds = decodeSessionToken(token)
 
     expect(creds.mode).toBe('test')
+  })
+
+  it('sets mode to sandbox when m is "sandbox"', () => {
+    const token = createToken({ ...validPayload, m: 'sandbox' })
+    const creds = decodeSessionToken(token)
+
+    expect(creds.mode).toBe('sandbox')
+  })
+
+  it('throws on an unrecognized mode instead of coercing to live', () => {
+    const token = createToken({ ...validPayload, m: 'anything' })
+    expect(() => decodeSessionToken(token)).toThrow('unknown mode "anything"')
   })
 
   it('throws on missing ck_ prefix', () => {


### PR DESCRIPTION
Stripe [Sandboxes](https://docs.stripe.com/sandboxes) supersede classic test mode and get their own account ID and credentials, so the Churnkey API treats `sandbox` as a third mode with its own credential bucket. The SDK couldn't express it: `Mode` was `'live' | 'test'` end to end, and `decodeSessionToken` coerced anything it didn't recognize to `'live'`. A sandbox-signed token wouldn't fail — it would run the cancel flow against live billing credentials.

- `Mode` is now `'live' | 'test' | 'sandbox'` in both `@churnkey/node` and `@churnkey/react`. In the react package the union derives from a single `MODES` const, so the decoder's runtime guard can't drift from the type.
- The decoder throws on an unrecognized mode instead of coercing to live. A missing `m` still defaults to `'live'`. Version skew between a newer `@churnkey/node` and an older `@churnkey/react` now fails loudly at integration time rather than silently hitting live Stripe.
- Session records map mode to the wire enum through an exhaustive switch (`toApiMode`), so adding a mode without a wire mapping is a compile error. Sandbox sessions record as `SANDBOX`, which the API already accepts.
- Playground mode selector gets a sandbox option; both READMEs document when to pass `'sandbox'`.

No server changes — the API already routes `x-ck-mode: sandbox` to the org's sandbox credentials.

Tests pin each layer: the decoder accepts `'sandbox'`, throws on unknown modes, and defaults to live when `m` is absent; `ChurnkeyApi` sends `x-ck-mode: sandbox`; the machine records `SANDBOX` in both analytics mode and token mode.

Releases `@churnkey/node` 0.2.0 and `@churnkey/react` 0.6.0 — changelogs in each package.