### PR TITLE
Expose externalId on PlanOption

### DIFF
--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -142,6 +142,12 @@ export interface PlanOption extends DirectPrice {
   features?: string[]
   /** Pre-formatted "before" price rendered struck-through (e.g. "$49/mo"). */
   msrp?: string
+  /**
+   * The merchant's external offer id for this plan, when configured in the
+   * cancel flow. Use it in `handlePlanChange` to map the chosen plan back to
+   * your own catalog when a single Stripe price backs several of your offers.
+   */
+  externalId?: string
 }
 
 export interface TrialExtensionOffer {


### PR DESCRIPTION
Adds `externalId?: string` to `PlanOption`. When a plan-change option is configured with a merchant's external offer id (see the churnkey-api change), the server sends it on the resolved plan; this types it so `handlePlanChange` consumers can map the chosen plan back to their own catalog — needed when one Stripe price backs several of their offers.

Non-breaking, type-only: the value already reaches the callback at runtime (the SDK config is cast, not field-mapped). typecheck + build + lint + tests clean.