### PR TITLE
fix(confirm): remove hardcoded "access continues until" notice

### DIFF
--- a/packages/react/src/components/steps/default-confirm.tsx
+++ b/packages/react/src/components/steps/default-confirm.tsx
@@ -1,4 +1,3 @@
-import { formatPeriodEnd } from '../../core/format'
 import type { ConfirmStepProps } from '../../core/types'
 import { cn } from '../../core/utils'
 import { RichText } from '../rich-text'
@@ -6,7 +5,6 @@ import { RichText } from '../rich-text'
 export function DefaultConfirm({
   title,
   description,
-  subscriptions,
   losses,
   lossesLabel,
   confirmLabel,
@@ -17,7 +15,6 @@ export function DefaultConfirm({
   classNames,
 }: ConfirmStepProps) {
   const hasLosses = Array.isArray(losses) && losses.length > 0
-  const periodEnd = formatPeriodEnd(subscriptions)
   return (
     <div className={cn('ck-step ck-step-confirm', classNames?.root)}>
       <h2 className={cn('ck-step-title', classNames?.title)}>{title}</h2>
@@ -37,10 +34,6 @@ export function DefaultConfirm({
             ))}
           </ul>
         </div>
-      )}
-
-      {periodEnd && (
-        <p className={cn('ck-period-end', classNames?.periodEndNotice)}>Your access continues until {periodEnd}.</p>
       )}
 
       <button

--- a/packages/react/tests/components/cancel-flow.test.tsx
+++ b/packages/react/tests/components/cancel-flow.test.tsx
@@ -374,7 +374,7 @@ describe('CancelFlow', () => {
     expect(screen.queryByLabelText('Additional detail')).toBeNull()
   })
 
-  it('renders the period-end notice when the active subscription has a current period', () => {
+  it('does not render an "access continues" notice on the confirm step', () => {
     render(
       <CancelFlow
         appId="app_test"
@@ -392,11 +392,10 @@ describe('CancelFlow', () => {
       />,
     )
 
-    // Intl.DateTimeFormat output varies by runtime locale; assert the
-    // notice fires and at least carries the year. Tighter date matching
-    // would couple the test to the test runner's locale.
-    const notice = screen.getByText(/Your access continues until .*2025/)
-    expect(notice).toBeInTheDocument()
+    // The hardcoded period-end notice was removed: it always rendered when the
+    // subscription had a current period, regardless of whether the cancel is
+    // immediate or end-of-cycle, so it could contradict the merchant's setting.
+    expect(screen.queryByText(/access continues until/i)).not.toBeInTheDocument()
   })
 
   it("marks the customer's current plan and excludes it from preselection", async () => {


### PR DESCRIPTION
## Why

Retention team feedback (Motley Fool): the **"Your access continues until {date}."** line on the confirm step must go. It rendered whenever the subscription had a `currentPeriod.end`, with no awareness of the cancel mode — so it showed even under "cancel immediate", where there is no continued access, and couldn't be turned off via config.

## Change

- Remove the `ck-period-end` notice (plus the now-unused `formatPeriodEnd(...)` call and import) from `DefaultConfirm`.
- Update the test to assert the line no longer renders.

`formatPeriodEnd`, the `periodEndNotice` classNames key, and the `.ck-period-end` CSS are left in place to keep the change non-breaking.

## Verification

- `vitest run` — 169 passed / 8 skipped
- `biome check` — clean
