### PR TITLE
Pass custom offers through the token-mode transform

### DIFF
--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -520,10 +520,8 @@ function SeatStep({
   )
 }
 
-// Renders the `annual_term_extension` custom offer type — the end-to-end check
-// that a type registered server-side, configured in the no-code builder, and
-// served through /cancel-flow/config renders via customComponents and reports
-// its result on accept. Config arrives as `offer.data` (here: days).
+// Custom offer type for the token-mode e2e path: builder config arrives as
+// offer.data (here: days), copy comes from the step's header/description.
 function AnnualTermExtension({ offer, onAccept, onDecline, isProcessing }: CustomOfferProps) {
   const data = (offer as { data?: Record<string, unknown> }).data ?? {}
   const days = (data.days as number) ?? 30

--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -520,6 +520,71 @@ function SeatStep({
   )
 }
 
+// Renders the `annual_term_extension` custom offer type — the end-to-end check
+// that a type registered server-side, configured in the no-code builder, and
+// served through /cancel-flow/config renders via customComponents and reports
+// its result on accept. Config arrives as `offer.data` (here: days).
+function AnnualTermExtension({ offer, onAccept, onDecline, isProcessing }: CustomOfferProps) {
+  const data = (offer as { data?: Record<string, unknown> }).data ?? {}
+  const days = (data.days as number) ?? 30
+
+  return (
+    <div className="ck-step ck-step-offer">
+      <h2 className="ck-step-title">{offer.copy.headline}</h2>
+      {offer.copy.body ? <p className="ck-step-description">{offer.copy.body}</p> : null}
+
+      <div className="ck-offer-card">
+        <div
+          style={{
+            padding: '24px 0',
+            textAlign: 'center',
+            background: 'var(--ck-color-surface-muted)',
+            borderRadius: 'var(--ck-radius-lg)',
+            marginBottom: 20,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 44,
+              fontWeight: 700,
+              lineHeight: 1,
+              fontVariantNumeric: 'tabular-nums',
+              letterSpacing: '-0.02em',
+              color: 'var(--ck-color-text)',
+            }}
+          >
+            +{days}
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              color: 'var(--ck-color-text-muted)',
+              marginTop: 4,
+              fontWeight: 600,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+            }}
+          >
+            free days on your annual term
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className="ck-button ck-button-primary"
+          onClick={() => onAccept({ days })}
+          disabled={isProcessing}
+        >
+          {isProcessing ? 'Extending…' : `Add ${days} free days`}
+        </button>
+        <button type="button" className="ck-button-link" onClick={onDecline}>
+          No thanks, cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function TestHarness() {
   const [appId, setAppId] = usePersistedField('appId')
   const [apiKey, setApiKey] = usePersistedField('apiKey')
@@ -887,6 +952,7 @@ export function TestHarness() {
           customComponents={{
             nps: NpsStep,
             'change-seats': SeatAdjuster,
+            annual_term_extension: AnnualTermExtension,
           }}
           onAccept={handleAccept}
           onCancel={handleCancel}

--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -1,4 +1,4 @@
-import { CancelFlow } from '@churnkey/react'
+import { CancelFlow, RichText } from '@churnkey/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import '@churnkey/react/styles.css'
 import type {
@@ -531,7 +531,7 @@ function AnnualTermExtension({ offer, onAccept, onDecline, isProcessing }: Custo
   return (
     <div className="ck-step ck-step-offer">
       <h2 className="ck-step-title">{offer.copy.headline}</h2>
-      {offer.copy.body ? <p className="ck-step-description">{offer.copy.body}</p> : null}
+      <RichText html={offer.copy.body} className="ck-step-description" />
 
       <div className="ck-offer-card">
         <div

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,4 +1,7 @@
 export { CancelFlow } from './cancel-flow'
+// Copy rendering — offer/step body may carry dashboard-authored HTML; this is
+// the renderer the built-in steps use, so custom components can match them.
+export { RichText } from './rich-text'
 // Steps
 export { DefaultConfirm } from './steps/default-confirm'
 export { DefaultFeedback } from './steps/default-feedback'

--- a/packages/react/src/core/api-types.ts
+++ b/packages/react/src/core/api-types.ts
@@ -67,6 +67,21 @@ export type SdkOffer =
   | SdkContactOffer
   | SdkRebateOffer
 
+/**
+ * A merchant-defined offer type. `type` is the registered key (matched against
+ * `customComponents`); `data` is the config values from the flow builder.
+ * Deliberately not part of the SdkOffer union — a `type: string` member would
+ * break the discriminated-union narrowing the transform's switch relies on.
+ * The wire can still carry it; the transform detects it by checking the type
+ * against the built-in list.
+ */
+export interface SdkCustomOffer {
+  type: string
+  data?: Record<string, unknown>
+  decisionId?: string
+  copy: SdkOfferCopy
+}
+
 interface SdkOfferBase {
   /** Per-offer guid — used for analytics joins between presented and accepted offers. */
   decisionId?: string

--- a/packages/react/src/core/api-types.ts
+++ b/packages/react/src/core/api-types.ts
@@ -67,25 +67,22 @@ export type SdkOffer =
   | SdkContactOffer
   | SdkRebateOffer
 
-/**
- * A merchant-defined offer type. `type` is the registered key (matched against
- * `customComponents`); `data` is the config values from the flow builder.
- * Deliberately not part of the SdkOffer union — a `type: string` member would
- * break the discriminated-union narrowing the transform's switch relies on.
- * The wire can still carry it; the transform detects it by checking the type
- * against the built-in list.
- */
-export interface SdkCustomOffer {
-  type: string
-  data?: Record<string, unknown>
-  decisionId?: string
-  copy: SdkOfferCopy
-}
-
 interface SdkOfferBase {
   /** Per-offer guid — used for analytics joins between presented and accepted offers. */
   decisionId?: string
   copy: SdkOfferCopy
+}
+
+/**
+ * A merchant-defined offer: `type` is the registered key (matched against
+ * `customComponents`), `data` the config values from the flow builder. Kept
+ * out of the SdkOffer union — a `type: string` member would break the
+ * narrowing the transform's switch relies on, so the transform detects it by
+ * checking the type against the built-in list instead.
+ */
+export interface SdkCustomOffer extends SdkOfferBase {
+  type: string
+  data?: Record<string, unknown>
 }
 
 export interface SdkDiscountOffer extends SdkOfferBase {

--- a/packages/react/src/core/transform.ts
+++ b/packages/react/src/core/transform.ts
@@ -78,10 +78,9 @@ function transformOfferDecision(o: SdkOffer): OfferDecision {
 }
 
 function transformOfferConfig(o: SdkOffer): OfferConfig {
-  // Merchant-defined offers arrive with the registered key as `type` and the
-  // builder's config as `data` — pass both through untouched so the renderer
-  // can match customComponents[type]. Without this the switch below returned
-  // undefined and the offer was silently dropped.
+  // Merchant-defined offers: `type` is the registered key and `data` the
+  // builder's config. Pass both through untouched so the renderer can match
+  // customComponents[type].
   if (!BUILT_IN_OFFER_TYPES.includes(o.type)) {
     const custom = o as unknown as SdkCustomOffer
     return custom.data !== undefined ? { type: custom.type, data: custom.data } : { type: custom.type }

--- a/packages/react/src/core/transform.ts
+++ b/packages/react/src/core/transform.ts
@@ -3,8 +3,9 @@
 // resolved — coupon ids hydrated to amounts and durations, plan ids inlined
 // as DirectPrice[], so this layer is a pure shape projection.
 
-import type { SdkConfig, SdkDiscountOffer, SdkOffer, SdkReason, SdkStep } from './api-types'
+import type { SdkConfig, SdkCustomOffer, SdkDiscountOffer, SdkOffer, SdkReason, SdkStep } from './api-types'
 import type { BuiltInOfferConfig, OfferConfig, OfferCopy, OfferDecision, ReasonConfig, Step } from './types'
+import { BUILT_IN_OFFER_TYPES } from './utils'
 
 export interface TransformResult {
   steps: Step[]
@@ -77,6 +78,14 @@ function transformOfferDecision(o: SdkOffer): OfferDecision {
 }
 
 function transformOfferConfig(o: SdkOffer): OfferConfig {
+  // Merchant-defined offers arrive with the registered key as `type` and the
+  // builder's config as `data` — pass both through untouched so the renderer
+  // can match customComponents[type]. Without this the switch below returned
+  // undefined and the offer was silently dropped.
+  if (!BUILT_IN_OFFER_TYPES.includes(o.type)) {
+    const custom = o as unknown as SdkCustomOffer
+    return custom.data !== undefined ? { type: custom.type, data: custom.data } : { type: custom.type }
+  }
   switch (o.type) {
     case 'discount': {
       const d: SdkDiscountOffer = o

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -193,6 +193,12 @@ export type OfferDecision = OfferConfig & { copy: OfferCopy; decisionId?: string
 
 export interface OfferCopy {
   headline: string
+  /**
+   * May contain HTML when the flow was authored in the Churnkey dashboard
+   * (the description editor is rich text). Render with the exported
+   * `RichText` component — the same renderer the built-in steps use — rather
+   * than as a text node, or the markup shows escaped.
+   */
   body: string
   cta: string
   declineCta: string

--- a/packages/react/tests/core/transform.test.ts
+++ b/packages/react/tests/core/transform.test.ts
@@ -156,4 +156,63 @@ describe('transformSdkConfig', () => {
     expect(offer.plans[0].id).toBe('plan_pro')
     expect(offer.plans[0].amount.value).toBe(4999)
   })
+
+  it('passes a merchant-defined offer through with its type key, data, copy, and decisionId', () => {
+    // The custom offer isn't part of the SdkOffer union (see SdkCustomOffer),
+    // so the fixture is cast — same shape the wire actually carries.
+    const config = {
+      blueprintId: 'bp_1',
+      steps: [
+        {
+          type: 'offer',
+          guid: 'o1',
+          offer: {
+            type: 'annual_term_extension',
+            data: { days: 30 },
+            decisionId: 'dec_1',
+            copy: { headline: 'Extend your term', body: 'On us', cta: 'Accept', declineCta: 'No thanks' },
+          },
+        },
+      ],
+      customer: { id: 'cus_1' },
+      subscriptions: [],
+      settings: { clickToCancelEnabled: false, strictFTCComplianceEnabled: false },
+    } as unknown as SdkConfig
+
+    const { steps } = transformSdkConfig(config)
+    const offer = (
+      steps[0] as {
+        offer: { type: string; data?: Record<string, unknown>; decisionId?: string; copy: { headline: string } }
+      }
+    ).offer
+    expect(offer.type).toBe('annual_term_extension')
+    expect(offer.data).toEqual({ days: 30 })
+    expect(offer.decisionId).toBe('dec_1')
+    expect(offer.copy.headline).toBe('Extend your term')
+  })
+
+  it('passes a custom offer with no data through as a bare type', () => {
+    const config = {
+      blueprintId: 'bp_1',
+      steps: [
+        {
+          type: 'offer',
+          guid: 'o1',
+          offer: {
+            type: 'winback_call',
+            decisionId: 'dec_2',
+            copy: { headline: 'Talk to us', body: '', cta: 'Accept', declineCta: 'No thanks' },
+          },
+        },
+      ],
+      customer: { id: 'cus_1' },
+      subscriptions: [],
+      settings: { clickToCancelEnabled: false, strictFTCComplianceEnabled: false },
+    } as unknown as SdkConfig
+
+    const { steps } = transformSdkConfig(config)
+    const offer = (steps[0] as { offer: { type: string; data?: unknown } }).offer
+    expect(offer.type).toBe('winback_call')
+    expect('data' in offer).toBe(false)
+  })
 })


### PR DESCRIPTION
Token-mode configs dropped merchant-defined offers. `transformOfferConfig` switches over the built-in wire types with no fallthrough, so an offer whose `type` is a registered custom key returned `undefined` — it reached the renderer with no type, failed the `customComponents` lookup, and was silently skipped. The server response was correct; local mode was unaffected because step-graph already passes custom offers through.

The fix checks the type against `BUILT_IN_OFFER_TYPES` before the switch and passes `{ type, data }` through unchanged. `SdkCustomOffer` is declared in api-types but kept out of the `SdkOffer` union, since a `type: string` member would break the narrowing the switch depends on. Two transform tests cover it; both fail without the fix.

Also exports `RichText`. Offer body is HTML when the flow was authored in the dashboard, and the built-in steps render it through RichText — custom components had no supported way to do the same, so markup showed escaped, and the likely workaround (integrators inlining their own dangerouslySetInnerHTML) would scatter the sanitization stance RichText exists to centralize. Documented on `OfferCopy.body`.

The playground harness gets an `annual_term_extension` component to exercise all of this against a locally built flow.