### PR TITLE
fix(mcp): advertise scopes_supported in PRM so generic OAuth clients can log in

### DIFF
--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { createServer as createNodeServer, type IncomingHttpHeaders, type ServerResponse } from 'node:http'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { DEFAULT_SCOPES } from './auth/oauth'
 import { type ChurnkeyMcpHttpConfig, loadHttpRequestConfig, loadHttpServerConfig, resolveBaseUrl } from './config'
 import { createServer } from './server'
 
@@ -62,6 +63,12 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
             resource: publicUrl,
             authorization_servers: [resolveAuthorizationServer(env)],
             bearer_methods_supported: ['header'],
+            // Advertise the supported scopes (RFC 9728 `scopes_supported`) so
+            // generic clients (Claude.ai, ChatGPT, Claude Code) know what to
+            // request. Without it they start the authorization request with an
+            // empty scope set, which the authorization server rejects with
+            // "At least one scope is required" — blocking login entirely.
+            scopes_supported: DEFAULT_SCOPES,
             resource_documentation: 'https://docs.churnkey.co/data-integrations/mcp',
           }),
         )

--- a/packages/mcp/tests/http.adversarial.test.ts
+++ b/packages/mcp/tests/http.adversarial.test.ts
@@ -309,10 +309,17 @@ describe('http — protected-resource metadata default URL', () => {
       resource: string
       authorization_servers: string[]
       bearer_methods_supported: string[]
+      scopes_supported: string[]
     }
     expect(body.resource).toBe('http://127.0.0.1:4555')
     expect(body.authorization_servers).toEqual(['https://api.churnkey.co'])
     expect(body.bearer_methods_supported).toEqual(['header'])
+    // RFC 9728: the PRM must advertise scopes so generic MCP clients request
+    // them; otherwise they authorize with an empty scope set and the AS rejects
+    // it ("At least one scope is required").
+    expect(Array.isArray(body.scopes_supported)).toBe(true)
+    expect(body.scopes_supported.length).toBeGreaterThan(0)
+    expect(body.scopes_supported).toContain('cancel_flows.blueprints.read')
     void base
   })
 


### PR DESCRIPTION
## What & why

Generic MCP OAuth clients (Claude.ai, ChatGPT, Claude Code) discover **which scopes to request** from the resource's [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource Metadata (PRM). Our PRM omitted `scopes_supported`, so those clients begin the authorization request with an **empty scope set** — and the authorization server rejects that with **"At least one scope is required"**, blocking OAuth login entirely.

Only the SDK CLI (`churnkey auth login`) was unaffected, because it sends `DEFAULT_SCOPES` explicitly.

### Confirmed against live metadata
- PRM `https://mcp.churnkey.co/.well-known/oauth-protected-resource` → `{ resource, authorization_servers, bearer_methods_supported, resource_documentation }` — **no `scopes_supported`**
- AS `https://api.churnkey.co/.well-known/oauth-authorization-server` → `scopes_supported` = 23 scopes (healthy)
- Rejection thrown in `churnkey-api` `oauth.controller.js` `validateAuthorizeParams` (empty scope → `BadRequest`)

**This affects prod (`mcp.churnkey.co`) and dev (`mcp-dev.churnkey.co`) identically** — both PRMs were missing the field. Any generic client hitting either environment fails the same way.

## The fix

Echo `DEFAULT_SCOPES` (the full supported set, matching the AS metadata's `scopes_supported`) from the PRM so clients know what to request. One import + one field.

## Testing

- `179/179` `@churnkey/mcp` tests pass; typecheck clean.
- New regression test boots the real HTTP server and asserts the live PRM advertises `scopes_supported`.

## Deploy

The PRM is served by the hosted HTTP server on Elastic Beanstalk, built from **this repo** (not npm). After merge:
- dev: `ops/mcp/deploy-mcp.sh dev`
- prod: `ops/mcp/deploy-mcp.sh prod`

## Notes

Standalone hotfix — **not** part of the MCP reslice stack (the PRM code merged earlier via #24). Discovered while QA-ing the MCP feature end-to-end against dev: the OAuth login itself was broken for the Claude Code client.

https://claude.ai/code/session_01HJRLEbMuREpbVfyNeMoP6h
