### PR TITLE
fix(pause offer): hide duration chips when only one option exists

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Expect breaking changes in minor versions while we're pre-1.0.
 
+## 0.6.3 — 2026-07-06
+
+### Fixed
+
+- `DefaultPauseOffer` no longer shows the duration chip selector when the offer only has one month to choose from.
+
 ## 0.6.2 — 2026-07-02
 
 ### Added

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Production-ready cancel flow for React. Drop-in component, headless hook, or full customization. Works standalone or with Churnkey for AI-powered retention.",
   "license": "MIT",
   "repository": {

--- a/packages/react/src/components/steps/offer/default-pause-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-pause-offer.tsx
@@ -32,19 +32,21 @@ export function DefaultPauseOffer({
       <div className={cn('ck-offer-card ck-pause-card', classNames?.card)}>
         <div className="ck-pause-eyebrow">We&apos;ll see you back on</div>
         <div className="ck-pause-date">{resumeDate}</div>
-        <div className={cn('ck-pause-chips', classNames?.pauseSlider)}>
-          {Array.from({ length: max }, (_, i) => i + 1).map((m) => (
-            <button
-              key={m}
-              type="button"
-              onClick={() => setMonths(m)}
-              className={cn('ck-pause-chip', m === months && 'ck-pause-chip--selected')}
-              aria-pressed={m === months}
-            >
-              {m} {m === 1 ? 'month' : 'months'}
-            </button>
-          ))}
-        </div>
+        {max > 1 && (
+          <div className={cn('ck-pause-chips', classNames?.pauseSlider)}>
+            {Array.from({ length: max }, (_, i) => i + 1).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMonths(m)}
+                className={cn('ck-pause-chip', m === months && 'ck-pause-chip--selected')}
+                aria-pressed={m === months}
+              >
+                {m} {m === 1 ? 'month' : 'months'}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
       <button
         type="button"


### PR DESCRIPTION
## Summary
- The pause offer's duration chip selector rendered even when `offer.months` was 1, showing a single already-selected chip.
- Now the chip selector is only rendered when there's more than one month to choose from.

## Test plan
- [x] `npm run test` / `npm run typecheck` (via pre-push hooks)
- [ ] Manually verify in playground with a single-month pause offer that the chips are hidden and the resume date still renders correctly