### PR TITLE
XDEV-2414 use configured cancellation timing

### DIFF
--- a/packages/react/src/core/api-types.ts
+++ b/packages/react/src/core/api-types.ts
@@ -18,6 +18,7 @@ export interface SdkConfig {
 export interface SdkSettings {
   clickToCancelEnabled: boolean
   strictFTCComplianceEnabled: boolean
+  cancelAtPeriodEnd?: boolean
   discountCooldown?: number
   pauseCooldown?: number
 }

--- a/packages/react/src/core/api.ts
+++ b/packages/react/src/core/api.ts
@@ -190,8 +190,11 @@ export class ChurnkeyApi {
     })
   }
 
-  async cancelSubscription(): Promise<void> {
-    await this.request(this.orgUrl('cancel-flow/actions/cancel'), { cancelAtPeriodEnd: true })
+  async cancelSubscription(cancelAtPeriodEnd = true, blueprintId?: string): Promise<void> {
+    await this.request(this.orgUrl('cancel-flow/actions/cancel'), {
+      cancelAtPeriodEnd,
+      ...(blueprintId && { blueprintId }),
+    })
   }
 
   async changePlan(planId: string): Promise<void> {

--- a/packages/react/src/core/machine.ts
+++ b/packages/react/src/core/machine.ts
@@ -406,7 +406,10 @@ export class CancelFlowMachine {
       if (this.callbacks.handleCancel) {
         await this.callbacks.handleCancel(customer)
       } else if (this.isTokenMode()) {
-        await this.apiClient!.cancelSubscription()
+        await this.apiClient!.cancelSubscription(
+          this.config?.settings.cancelAtPeriodEnd ?? true,
+          this.blueprintId ?? undefined,
+        )
       }
 
       await this.callbacks.onCancel?.(customer)

--- a/packages/react/tests/core/api.test.ts
+++ b/packages/react/tests/core/api.test.ts
@@ -47,12 +47,20 @@ describe('ChurnkeyApi action paths', () => {
     expect(calledBody(spy)).toEqual({ duration: 2, interval: 'month' })
   })
 
-  it('cancelSubscription hits cancel-flow/actions/cancel with cancelAtPeriodEnd: true', async () => {
+  it('cancelSubscription defaults to cancelAtPeriodEnd: true', async () => {
     const spy = spyFetch()
     const api = new ChurnkeyApi(creds, 'https://api.test/v1')
     await api.cancelSubscription()
     expect(calledPath(spy)).toBe('https://api.test/v1/api/orgs/app_test/cancel-flow/actions/cancel')
     expect(calledBody(spy)).toEqual({ cancelAtPeriodEnd: true })
+  })
+
+  it('cancelSubscription forwards explicit cancellation timing and blueprint policy hint', async () => {
+    const spy = spyFetch()
+    const api = new ChurnkeyApi(creds, 'https://api.test/v1')
+    await api.cancelSubscription(false, 'bp_1')
+    expect(calledPath(spy)).toBe('https://api.test/v1/api/orgs/app_test/cancel-flow/actions/cancel')
+    expect(calledBody(spy)).toEqual({ cancelAtPeriodEnd: false, blueprintId: 'bp_1' })
   })
 
   it('changePlan hits cancel-flow/actions/change-plan with planId', async () => {

--- a/packages/react/tests/core/machine.test.ts
+++ b/packages/react/tests/core/machine.test.ts
@@ -461,19 +461,30 @@ describe('CancelFlowMachine', () => {
         steps: [{ type: 'survey', reasons: [{ id: 'r1', label: 'Missing features' }] }, { type: 'confirm' }],
         onCancel,
       })
-      machine.initializeFromConfig(sdkConfig({ blueprintId: 'bp_1' }), mockApi as any, {
-        appId: 'a',
-        customerId: 'c',
-        authHash: 'h',
-        mode: 'live' as const,
-        issuedAt: 0,
-      })
+      machine.initializeFromConfig(
+        sdkConfig({
+          blueprintId: 'bp_1',
+          settings: {
+            clickToCancelEnabled: false,
+            strictFTCComplianceEnabled: false,
+            cancelAtPeriodEnd: false,
+          },
+        }),
+        mockApi as any,
+        {
+          appId: 'a',
+          customerId: 'c',
+          authHash: 'h',
+          mode: 'live' as const,
+          issuedAt: 0,
+        },
+      )
       machine.selectReason('r1')
       machine.next()
       await machine.cancel()
 
       expect(calls).toEqual(['action', 'onCancel'])
-      expect(mockApi.cancelSubscription).toHaveBeenCalled()
+      expect(mockApi.cancelSubscription).toHaveBeenCalledWith(false, 'bp_1')
     })
   })
 


### PR DESCRIPTION
## Summary
- add `settings.cancelAtPeriodEnd` to SDK config types
- pass configured cancellation timing into token-mode cancel actions
- cover default and explicit timing in API and machine tests

## Impact
React SDK token-mode flows no longer hard-code end-of-cycle cancellation. They use the timing returned by the API config endpoint, with end-of-cycle as the backward-compatible fallback.

## Validation
- `pnpm --filter @churnkey/react test -- tests/core/api.test.ts tests/core/machine.test.ts`
- `pnpm --filter @churnkey/react typecheck`
- pre-push hook also ran full `turbo typecheck` and `turbo test` successfully

## Related
- XDEV-2414
- API PR returns the setting from `/cancel-flow/config`
- Builder/runtime PR persists and uses the flow setting