### PR TITLE
Render embedded video responsively in cancel-flow steps

### DIFF
--- a/apps/playground/src/TestHarness.tsx
+++ b/apps/playground/src/TestHarness.tsx
@@ -529,7 +529,7 @@ function AnnualTermExtension({ offer, onAccept, onDecline, isProcessing }: Custo
   return (
     <div className="ck-step ck-step-offer">
       <h2 className="ck-step-title">{offer.copy.headline}</h2>
-      <RichText html={offer.copy.body} className="ck-step-description" />
+      <RichText as="div" html={offer.copy.body} className="ck-step-description" />
 
       <div className="ck-offer-card">
         <div

--- a/packages/react/src/components/steps/default-confirm.tsx
+++ b/packages/react/src/components/steps/default-confirm.tsx
@@ -18,7 +18,9 @@ export function DefaultConfirm({
   return (
     <div className={cn('ck-step ck-step-confirm', classNames?.root)}>
       <h2 className={cn('ck-step-title', classNames?.title)}>{title}</h2>
-      {description && <RichText html={description} className={cn('ck-step-description', classNames?.description)} />}
+      {description && (
+        <RichText as="div" html={description} className={cn('ck-step-description', classNames?.description)} />
+      )}
 
       {hasLosses && (
         <div className={cn('ck-loss-block', classNames?.lossList)}>

--- a/packages/react/src/components/steps/default-feedback.tsx
+++ b/packages/react/src/components/steps/default-feedback.tsx
@@ -23,7 +23,9 @@ export function DefaultFeedback({
   return (
     <div className={cn('ck-step ck-step-feedback', classNames?.root)}>
       <h2 className={cn('ck-step-title', classNames?.title)}>{title}</h2>
-      {description && <RichText html={description} className={cn('ck-step-description', classNames?.description)} />}
+      {description && (
+        <RichText as="div" html={description} className={cn('ck-step-description', classNames?.description)} />
+      )}
 
       <div
         className={cn(

--- a/packages/react/src/components/steps/default-success.tsx
+++ b/packages/react/src/components/steps/default-success.tsx
@@ -11,7 +11,9 @@ export function DefaultSuccess({ title, description, onClose, classNames }: Succ
       </div>
 
       <h2 className={cn('ck-step-title', classNames?.title)}>{title}</h2>
-      {description && <RichText html={description} className={cn('ck-step-description', classNames?.description)} />}
+      {description && (
+        <RichText as="div" html={description} className={cn('ck-step-description', classNames?.description)} />
+      )}
 
       <div className="ck-success-actions">
         <button type="button" className={cn('ck-button ck-button-primary', classNames?.closeButton)} onClick={onClose}>

--- a/packages/react/src/components/steps/default-survey.tsx
+++ b/packages/react/src/components/steps/default-survey.tsx
@@ -41,7 +41,9 @@ export function DefaultSurvey({
   return (
     <div className={cn('ck-step ck-step-survey', classNames?.root)}>
       <h2 className={cn('ck-step-title', classNames?.title)}>{title}</h2>
-      {description && <RichText html={description} className={cn('ck-step-description', classNames?.description)} />}
+      {description && (
+        <RichText as="div" html={description} className={cn('ck-step-description', classNames?.description)} />
+      )}
 
       <div className={cn('ck-reason-list', classNames?.reasonList)} role="radiogroup" aria-label={title}>
         {reasons.map((reason, i) => (

--- a/packages/react/src/components/steps/offer/default-contact-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-contact-offer.tsx
@@ -21,7 +21,7 @@ export function DefaultContactOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         <button

--- a/packages/react/src/components/steps/offer/default-discount-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-discount-offer.tsx
@@ -25,7 +25,7 @@ export function DefaultDiscountOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         <div className="ck-offer-details ck-offer-discount">

--- a/packages/react/src/components/steps/offer/default-pause-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-pause-offer.tsx
@@ -27,7 +27,7 @@ export function DefaultPauseOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card ck-pause-card', classNames?.card)}>
         <div className="ck-pause-eyebrow">We&apos;ll see you back on</div>

--- a/packages/react/src/components/steps/offer/default-plan-change-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-plan-change-offer.tsx
@@ -35,7 +35,7 @@ export function DefaultPlanChangeOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         <div className="ck-offer-details ck-plan-grid">

--- a/packages/react/src/components/steps/offer/default-rebate-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-rebate-offer.tsx
@@ -33,7 +33,7 @@ export function DefaultRebateOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         {/* paid / money back / net, like an invoice. Paid and net only exist in token mode. */}

--- a/packages/react/src/components/steps/offer/default-redirect-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-redirect-offer.tsx
@@ -10,7 +10,7 @@ export function DefaultRedirectOffer({ title, description, offer, onDecline, cla
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         <div className="ck-offer-details">

--- a/packages/react/src/components/steps/offer/default-trial-extension-offer.tsx
+++ b/packages/react/src/components/steps/offer/default-trial-extension-offer.tsx
@@ -22,7 +22,7 @@ export function DefaultTrialExtensionOffer({
   return (
     <div className={cn('ck-step ck-step-offer', classNames?.root)}>
       {headline && <h2 className={cn('ck-step-title', classNames?.title)}>{headline}</h2>}
-      {body && <RichText html={body} className={cn('ck-step-description', classNames?.description)} />}
+      {body && <RichText as="div" html={body} className={cn('ck-step-description', classNames?.description)} />}
 
       <div className={cn('ck-offer-card', classNames?.card)}>
         <div className="ck-offer-details ck-trial-block">

--- a/packages/react/src/core/types.ts
+++ b/packages/react/src/core/types.ts
@@ -197,7 +197,9 @@ export interface OfferCopy {
    * May contain HTML when the flow was authored in the Churnkey dashboard
    * (the description editor is rich text). Render with the exported
    * `RichText` component — the same renderer the built-in steps use — rather
-   * than as a text node, or the markup shows escaped.
+   * than as a text node, or the markup shows escaped. Pass `as="div"` (built-in
+   * steps do) so block content like an embedded video iframe isn't hoisted out
+   * of the default `<p>` wrapper.
    */
   body: string
   cta: string

--- a/packages/react/src/styles/cancel-flow.css
+++ b/packages/react/src/styles/cancel-flow.css
@@ -275,6 +275,19 @@
   margin: 0 0 20px;
 }
 
+/* Embedded video (YouTube/Vimeo/Wistia/Brightcove iframes) authored into a
+   step description. Overrides the inline height="480" the TipTap YouTube node
+   emits and makes the player fill the width at a 16:9 box. */
+.ck-cancel-flow .ck-step-description :is(iframe, video),
+.ck-cancel-flow .ck-step-description [data-youtube-video] {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  border-radius: 10px;
+}
+
 /* --- Buttons --- */
 .ck-cancel-flow .ck-button {
   display: inline-flex;


### PR DESCRIPTION
> 📄 **Scope & design:** [Video Embeds Beyond YouTube — Cancel Flow Scope](https://derive.to/artifacts/video-embeds-beyond-youtube-cancel-flow-scope-d3tnnx3y)
> 🧐 **Companion PR Review:** [Review Companion](https://derive.to/artifacts/review-companion-video-embeds-beyond-youtube-3-p-q5rh9ezm)

## Why

Step descriptions render through `RichText`, which defaults to a `<p>` wrapper. A block-level video (`<iframe>` / `<div data-youtube-video>`) authored into a description gets hoisted out of the paragraph by the browser, leaving stray empty `<p>`s. And there's no responsive sizing, so the player renders at the TipTap YouTube node's inline `height="480"` at a fixed width.

## What

- Render description/body `RichText` as `<div>` (`as="div"`) at the 11 step-component call sites, so block-level embeds aren't hoisted.
- Add responsive 16:9 media CSS under `.ck-step-description` (`iframe`, `video`, `[data-youtube-video]`) — fills width, overrides the inline `height="480"`.

Companion to the builder (monorepo #267) and embed (#223) PRs that let non-YouTube embeds through in the first place.

## Tests

Full suite 172 pass; biome clean.
