### PR TITLE
Read the OAuth bearer token per request in the MCP HTTP transport (XDEV-2487)

### DIFF
--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -128,6 +128,12 @@ function unauthorizedHint(authKind: ChurnkeyAuth['kind']): string {
   if (authKind === 'data-api-key') {
     return 'Churnkey API rejected the credentials. Check CHURNKEY_APP_ID and CHURNKEY_API_KEY in your MCP server config — or switch to OAuth with `npx @churnkey/mcp auth login`.'
   }
+  if (authKind === 'bearer') {
+    // Hosted transport: the MCP client owns the token and its refresh, so there
+    // is no CLI to run. Telling a connector user to run `auth login` sent them
+    // to re-authorize by hand — the one instruction that must NOT appear here.
+    return 'Churnkey rejected the OAuth access token (expired or revoked). Your MCP client should refresh it automatically; if this persists, reconnect the Churnkey connector.'
+  }
   return 'Churnkey API rejected the OAuth session (expired or revoked). Run `npx @churnkey/mcp auth login` to sign in again.'
 }
 

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import { createServer as createNodeServer, type IncomingHttpHeaders, type ServerResponse } from 'node:http'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { DEFAULT_SCOPES } from './auth/oauth'
@@ -7,11 +6,15 @@ import { createServer } from './server'
 
 type HttpServer = ReturnType<typeof createNodeServer>
 
-interface HttpSession {
-  transport: StreamableHTTPServerTransport
-}
-
 const PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource'
+
+/**
+ * Thrown when a request carries no usable Churnkey credentials. Distinguished
+ * from every other failure so only a genuine auth problem answers with 401 +
+ * WWW-Authenticate — an unrelated crash answering 401 tells an OAuth client its
+ * token is dead and sends the user back through the consent screen for nothing.
+ */
+class MissingCredentialsError extends Error {}
 
 // The canonical public URL of THIS MCP server (e.g. https://mcp.churnkey.co),
 // advertised as the OAuth resource identifier. Defaults to the local bind
@@ -32,7 +35,6 @@ function resolveAuthorizationServer(env: NodeJS.ProcessEnv): string {
 
 export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Promise<HttpServer> {
   const config = loadHttpServerConfig(env)
-  const sessions = new Map<string, HttpSession>()
   // Recomputed once the server is listening so an ephemeral (port 0) bind
   // advertises its real port; the request handler reads these by reference.
   let publicUrl = resolvePublicUrl(config, env)
@@ -85,46 +87,55 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
         return
       }
 
-      const sessionId = getHeader(req.headers, 'mcp-session-id')
-      const existing = sessionId ? sessions.get(sessionId) : undefined
-
-      if (existing) {
-        await existing.transport.handleRequest(req, res)
-        return
-      }
-
-      if (sessionId) {
-        res.writeHead(404, { 'content-type': 'text/plain' }).end('MCP session not found')
-        return
-      }
-
       if (req.method !== 'POST') {
-        // A GET/DELETE with no session is a transport probe, not a stream. MCP
-        // clients (notably Claude.ai) expect 405 + Allow here; a 400 breaks
-        // their transport detection.
+        // Stateless mode has no standalone SSE stream and no session to delete,
+        // so GET/DELETE are transport probes. MCP clients (notably Claude.ai)
+        // expect 405 + Allow here; a 400 breaks their transport detection, and
+        // 405 is the spec's sanctioned "session termination not supported".
         res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' }).end('Method Not Allowed')
         return
       }
 
-      const requestConfig = loadHttpRequestConfig(toFetchHeaders(req.headers), env)
-      const server = createServer(requestConfig)
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: randomUUID,
-        onsessioninitialized: (initializedSessionId) => {
-          sessions.set(initializedSessionId, { transport })
-        },
-      })
-
-      transport.onclose = () => {
-        const initializedSessionId = transport.sessionId
-        if (initializedSessionId) sessions.delete(initializedSessionId)
+      // Credentials are read from THIS request, every request — the transport is
+      // stateless (`sessionIdGenerator: undefined`), so a fresh server+client
+      // pair is built per request and nothing carries over between them.
+      //
+      // Load-bearing, not stylistic. While the transport was stateful the bearer
+      // token was captured once on `initialize` and reused for the life of the
+      // session, so a hosted OAuth session died as soon as its 1-hour access
+      // token expired: the client refreshed correctly, the new token arrived on
+      // later requests, and we ignored it (XDEV-2487). Reading the header per
+      // request is what lets a refreshed token take effect. It also drops the
+      // sticky-routing requirement, and matches where the protocol is going —
+      // SEP-2575 removes Mcp-Session-Id and requires every request to be
+      // authenticated on its own. A stale session id from a client that
+      // connected before this change is simply ignored, so live sessions
+      // migrate without a reconnect.
+      let requestConfig: ReturnType<typeof loadHttpRequestConfig>
+      try {
+        requestConfig = loadHttpRequestConfig(toFetchHeaders(req.headers), env)
+      } catch (err) {
+        throw new MissingCredentialsError(err instanceof Error ? err.message : String(err))
       }
+
+      const server = createServer(requestConfig)
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+      // Per-request lifetime: tear both down once the response is done, or the
+      // per-request servers would accumulate exactly like the sessions did.
+      res.once('close', () => {
+        void transport.close()
+        void server.close()
+      })
 
       await server.connect(transport)
       await transport.handleRequest(req, res)
     } catch (err) {
-      if (!res.headersSent) {
-        const message = err instanceof Error ? err.message : String(err)
+      if (res.headersSent) {
+        res.end()
+        return
+      }
+      const message = err instanceof Error ? err.message : String(err)
+      if (err instanceof MissingCredentialsError) {
         // Point OAuth-capable MCP clients at the resource metadata (MCP auth spec).
         res
           .writeHead(401, {
@@ -132,9 +143,11 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
             'www-authenticate': `Bearer resource_metadata="${resourceMetadataUrl}"`,
           })
           .end(message)
-      } else {
-        res.end()
+        return
       }
+      // Anything else is our fault, not the caller's credentials. Answering 401
+      // here would make an OAuth client discard a perfectly good token.
+      res.writeHead(500, { 'content-type': 'text/plain' }).end(message)
     }
   })
 
@@ -152,14 +165,6 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
   const boundPort = typeof address === 'object' && address !== null ? address.port : config.port
   publicUrl = resolvePublicUrl(config, env, boundPort)
   resourceMetadataUrl = `${publicUrl}${PROTECTED_RESOURCE_PATH}`
-
-  const closeSessions = async () => {
-    await Promise.all([...sessions.values()].map(({ transport }) => transport.close()))
-    sessions.clear()
-  }
-  httpServer.once('close', () => {
-    void closeSessions()
-  })
 
   console.error(`Churnkey MCP HTTP server listening at http://${config.host}:${boundPort}${config.path}`)
   return httpServer

--- a/packages/mcp/tests/client.adversarial.test.ts
+++ b/packages/mcp/tests/client.adversarial.test.ts
@@ -174,6 +174,21 @@ describe('ChurnkeyClient — mapErrorMessage per auth kind', () => {
     await expect(dataClient().get('/data/x')).rejects.toThrow(/CHURNKEY_APP_ID/)
   })
 
+  it('401 bare body for a hosted bearer token → connector hint, never the CLI command', async () => {
+    // The hosted transport has no local token store, so `auth login` is not a
+    // thing the caller can do — surfacing it is what pushed connector users into
+    // re-authorizing by hand (XDEV-2487).
+    fetchOnce('unauthorized', 401)
+    const client = new ChurnkeyClient({
+      baseUrl: 'https://api.example.com/v1',
+      auth: { kind: 'bearer', token: 'ck_oat_x' },
+    })
+    const err = await client.get('/data/x').catch((e: Error) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/reconnect the Churnkey connector/i)
+    expect((err as Error).message).not.toMatch(/auth login/)
+  })
+
   it('401 with a short (<25 char) message falls back to the hint', async () => {
     fetchOnce('nope', 401)
     await expect(dataClient().get('/data/x')).rejects.toThrow(/credentials/i)

--- a/packages/mcp/tests/http.adversarial.test.ts
+++ b/packages/mcp/tests/http.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { request as httpRequest, type Server } from 'node:http'
+import { createServer as createNodeServer, request as httpRequest, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
 import { startHttpServer } from '../src/http'
@@ -69,7 +69,7 @@ describe('http — routing', () => {
     expect(res.status).toBe(405)
   })
 
-  it('GET to /mcp with no session id → 405 Method Not Allowed + Allow: POST', async () => {
+  it('GET to /mcp → 405 Method Not Allowed + Allow: POST', async () => {
     const { base } = await start()
     const res = await fetch(`${base}/mcp`, { method: 'GET' })
     expect(res.status).toBe(405)
@@ -77,15 +77,20 @@ describe('http — routing', () => {
     expect(await res.text()).toBe('Method Not Allowed')
   })
 
-  it('request with an unknown mcp-session-id → 404 session not found', async () => {
+  it('ignores an unrecognized mcp-session-id instead of 404ing (stateless: clients that connected before the change keep working)', async () => {
     const { base } = await start()
     const res = await fetch(`${base}/mcp`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'mcp-session-id': 'does-not-exist' },
-      body: '{}',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'x-ck-app': 'app_test',
+        'x-ck-api-key': 'key_test',
+        'mcp-session-id': 'session-from-a-previous-deploy',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
     })
-    expect(res.status).toBe(404)
-    expect(await res.text()).toBe('MCP session not found')
+    expect(res.status).toBe(200)
   })
 })
 
@@ -204,7 +209,7 @@ describe('http — auth error → 401 with WWW-Authenticate', () => {
     expect(await res.text()).toMatch(/App ID|credentials/i)
   })
 
-  it('a Data API key request (valid headers) connects a session and returns a session id', async () => {
+  it('a Data API key request (valid headers) reaches the MCP transport', async () => {
     const { base } = await start()
     const res = await fetch(`${base}/mcp`, {
       method: 'POST',
@@ -225,80 +230,95 @@ describe('http — auth error → 401 with WWW-Authenticate', () => {
         },
       }),
     })
-    // The MCP transport handled it and assigned a session — proves the create/connect path runs.
+    // The transport handled it — proves the create/connect path runs.
     expect(res.status).toBe(200)
-    expect(res.headers.get('mcp-session-id')).toBeTruthy()
+    // Stateless: no session is minted, so no session id comes back.
+    expect(res.headers.get('mcp-session-id')).toBeNull()
+  })
+
+  it('a non-auth failure answers 500, NOT 401 — a 401 would make an OAuth client discard a good token', async () => {
+    const { base } = await start()
+    // A body that is not valid JSON fails inside the transport, well past the
+    // credential check. Before this was narrowed, every such failure came back
+    // as 401 + WWW-Authenticate.
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'x-ck-app': 'app_test',
+        'x-ck-api-key': 'key_test',
+      },
+      body: 'not json at all',
+    })
+    expect(res.status).not.toBe(401)
+    expect(res.headers.get('www-authenticate')).toBeNull()
   })
 })
 
-describe('http — session lifecycle (create, reuse, cleanup)', () => {
-  it('reuses a session on the second request and tears it down on DELETE', async () => {
-    const { port } = await start()
-    const headers = {
-      'content-type': 'application/json',
-      accept: 'application/json, text/event-stream',
-      'x-ck-app': 'app_test',
-      'x-ck-api-key': 'key_test',
+describe('http — the bearer token is read from every request', () => {
+  /**
+   * The regression guard for XDEV-2487.
+   *
+   * A hosted OAuth access token lives one hour. MCP clients refresh it and send
+   * the new one on subsequent requests. When the transport was stateful, the
+   * token captured on `initialize` was reused for the life of the session, so
+   * every hosted connector broke exactly one hour after connecting and stayed
+   * broken until the user re-authorized by hand.
+   *
+   * Asserted against a stub API that records the Authorization header it is
+   * handed, because the only thing that actually matters is which token reaches
+   * Churnkey — not what the transport was told.
+   */
+  it('forwards the token from the CURRENT request, not the one that opened the connection', async () => {
+    const received: string[] = []
+    const api = createNodeServer((req, res) => {
+      received.push(req.headers.authorization ?? '(none)')
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ ok: true }))
+    })
+    await new Promise<void>((resolve) => api.listen(0, '127.0.0.1', resolve))
+    const apiPort = (api.address() as AddressInfo).port
+
+    try {
+      const { base } = await start({ CHURNKEY_API_URL: `http://127.0.0.1:${apiPort}` })
+      const first = `ck_oat_${'a'.repeat(64)}`
+      const refreshed = `ck_oat_${'b'.repeat(64)}`
+
+      // The response is an SSE stream, so it must be drained to completion —
+      // fetch resolves on headers alone, before the tool has actually run.
+      const callTool = async (token: string) => {
+        const res = await fetch(`${base}/mcp`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: { name: 'get_account', arguments: {} },
+          }),
+        })
+        return { status: res.status, body: await res.text() }
+      }
+
+      const firstCall = await callTool(first)
+      expect(firstCall.status).toBe(200)
+      // No isError — the call actually reached the stub and succeeded.
+      expect(firstCall.body).not.toContain('isError')
+
+      const refreshedCall = await callTool(refreshed)
+      expect(refreshedCall.status).toBe(200)
+      expect(refreshedCall.body).not.toContain('isError')
+
+      expect(received).toEqual([`Bearer ${first}`, `Bearer ${refreshed}`])
+    } finally {
+      await new Promise((resolve) => api.close(resolve))
     }
-    const initRes = await rawRequest(port, {
-      method: 'POST',
-      host: '127.0.0.1',
-      headers,
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
-      }),
-    })
-    expect(initRes.status).toBe(200)
-    // Grab the session id from the response headers via a fetch (rawRequest doesn't expose them).
-    const sid = await getSessionId(port, headers)
-    expect(sid).toBeTruthy()
-
-    // Second request WITH the session id → routed to the existing transport (handleRequest path).
-    const reuse = await rawRequest(port, {
-      method: 'POST',
-      host: '127.0.0.1',
-      headers: { ...headers, 'mcp-session-id': sid! },
-      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
-    })
-    // The existing transport handled it (202 Accepted for a notification, or 200) — not a 404.
-    expect(reuse.status).not.toBe(404)
-
-    // DELETE with the session id → transport closes → onclose deletes the session.
-    const del = await rawRequest(port, {
-      method: 'DELETE',
-      host: '127.0.0.1',
-      headers: { ...headers, 'mcp-session-id': sid! },
-    })
-    expect(del.status).not.toBe(404)
-
-    // After close, the session id is no longer known → 404.
-    const afterClose = await rawRequest(port, {
-      method: 'POST',
-      host: '127.0.0.1',
-      headers: { ...headers, 'mcp-session-id': sid! },
-      body: '{}',
-    })
-    expect(afterClose.status).toBe(404)
   })
 })
-
-/** Helper: initialize a session and return its mcp-session-id (fetch exposes response headers). */
-async function getSessionId(port: number, headers: Record<string, string>): Promise<string | null> {
-  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } },
-    }),
-  })
-  return res.headers.get('mcp-session-id')
-}
 
 describe('http — protected-resource metadata default URL', () => {
   it('builds the default public URL from the CONFIGURED host:port (an explicit port)', async () => {


### PR DESCRIPTION
Fixes [XDEV-2487](https://linear.app/churnkey/issue/XDEV-2487/fix-mcp-http-transport-pinning-the-oauth-access-token-at-session). Reported by a customer: *"I have to re-authorize the connector on Claude every couple of hours or so."*

## The bug

The hosted Streamable HTTP transport read the bearer token **once**, on the `initialize` POST, and pinned it for the life of the MCP session:

- `http.ts` — a POST with no `mcp-session-id` called `loadHttpRequestConfig(headers)` and baked the literal token into `createServer(requestConfig)`; every later request went straight to `existing.transport.handleRequest(req, res)`, never re-reading `Authorization`.
- `client.ts` — for `kind: 'bearer'` the token is a static field, and the 401-refresh-retry is gated to `kind === 'oauth'` (the local stdio store). The hosted path had no refresh path at all.
- The session `Map` had no TTL or eviction, so a dead session persisted indefinitely.

Access tokens live 1 hour. So a connector session worked for exactly one hour after connecting, then broke permanently. Claude refreshed correctly — we discarded the new token. Re-authorizing was the only fix, because it forced a new `initialize`.

Made worse by the error text surfaced in that state: *"Run `npx @churnkey/mcp auth login` to sign in again"* — CLI advice shown to a web-connector user, so the only actionable-looking instruction was "re-authenticate".

## The fix

Stateless transport (`sessionIdGenerator: undefined`); the server + client are built per request from that request's own headers. Also removes the unbounded session map and the sticky-routing requirement, and aligns with [SEP-2575](https://modelcontextprotocol.io/seps/2575-stateless-mcp) (Final), which drops `Mcp-Session-Id` and requires every request to be independently authenticated.

Two related fixes ride along:

- **Only genuine missing-credentials failures answer 401 + `WWW-Authenticate`.** The previous catch-all returned 401 for *any* thrown error, telling OAuth clients their token was dead when it wasn't.
- **`unauthorizedHint` no longer sends hosted users to the CLI.**

## Evidence it was real

Local repro against a stub API, before the change — same session, second call sends a refreshed token B:

```
initialize (token A) -> session 06a691dd…
tools/call token A   -> API received token A
tools/call token B   -> API received token A   <- refreshed token discarded
new session token B  -> API received token B   <- only a reconnect picks it up
```

Prod (read-only), across all orgs:

| Client | Grants | p90 usable span | Survived >60 min |
|---|---|---|---|
| claude.ai connector (HTTP transport) | 21 | **59.3 min** | **2 / 21** |
| local CLI (stdio, refreshes internally) | 49 | 12,655 min (8.8 d) | 15 / 49 |

Same authorization server, same 1h TTL — the only difference is whether the transport re-reads the token. Also **247 refresh rotations after a grant's last successful API call** across 15 of 21 Claude grants: the client refreshing for days while `lastActivityAt` never advanced. Affected 4 customers.

## Tests

`237 passed` in `packages/mcp`, clean typecheck and biome. (The 48 failures in a full-monorepo `vitest run` are pre-existing on `main` in other packages — verified by stashing; this branch takes passing tests 421 → 423.)

Added:
- **`forwards the token from the CURRENT request, not the one that opened the connection`** — the regression guard. Asserts against a stub API that records the `Authorization` header it receives, because the only thing that matters is which token actually reaches Churnkey. Fails on the old code.
- **`a non-auth failure answers 500, NOT 401`** — pins the narrowed catch-all.
- **`ignores an unrecognized mcp-session-id instead of 404ing`** — pins graceful migration for clients that connected before this change.
- **`401 bare body for a hosted bearer token → connector hint, never the CLI command`**.

Updated the stateful-session lifecycle test, which asserted behavior this change removes.

## Deploy note

Existing connector sessions migrate without user action: a stale `Mcp-Session-Id` is ignored rather than 404'd. Ships via `ops/mcp/deploy-mcp.sh`.

## Follow-ups (not in this PR)

- Have the API's 401 reach the client as HTTP 401 + `WWW-Authenticate: Bearer error="invalid_token"` rather than a 200 `isError` tool result, so clients refresh silently on mid-request expiry.
- `churnkey-api`'s `mcp-usage-tracker.js` skips unattributed calls, so auth failures are invisible in telemetry — org who reported this showed a 100% success rate throughout. Separate repo.
