### PR TITLE
prepare @churnkey/mcp 1.1.1

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 1.1.1 — 2026-07-30
+
+### Fixed
+
+- Hosted HTTP transport: the OAuth bearer token is now read from every request instead of being captured once on `initialize` and reused for the life of the session. A session pinned to an expired access token kept failing even after the client sent a refreshed one, so hosted connectors stopped working an hour after connecting and only recovered when the user re-authorized. The transport is now stateless (no `Mcp-Session-Id`), which also removes the per-session server accumulation and the sticky-routing requirement. Clients connected before the upgrade migrate without reconnecting — an unrecognized session id is ignored rather than rejected.
+- Only a genuine missing-credentials failure answers `401` with `WWW-Authenticate`; other errors now answer `500`. The previous catch-all returned `401` for any thrown error, which told OAuth clients their token was invalid when it was fine.
+- The `401` hint for hosted bearer tokens no longer suggests running `npx @churnkey/mcp auth login`. That path has no local token store, so the advice was not actionable and pushed connector users into re-authorizing by hand.
+
+Local stdio users were unaffected by all three — that path refreshes its own token and retries on `401`.
+
 ## 1.1.0 — 2026-07-15
 
 ### Added

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Model Context Protocol server for Churnkey. Lets agents query sessions, payment-recovery analytics, and DSR endpoints with a Data API key.",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,7 +5,7 @@ import { allTools } from './tools'
 import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from './tools/shared'
 
 export const SERVER_NAME = 'churnkey-mcp'
-export const SERVER_VERSION = '1.1.0'
+export const SERVER_VERSION = '1.1.1'
 
 export function createServer(config: ChurnkeyMcpConfig): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION })

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -80,7 +80,7 @@ afterEach(() => {
 describe('server metadata', () => {
   it('exposes a stable name + version', () => {
     expect(SERVER_NAME).toBe('churnkey-mcp')
-    expect(SERVER_VERSION).toBe('1.1.0')
+    expect(SERVER_VERSION).toBe('1.1.1')
   })
 
   it('builds without throwing for each auth kind', () => {


### PR DESCRIPTION
Version bump only — publishes the per-request OAuth token fix from #42 to npm.

`1.1.0` is already on the registry, so the fix can't be published without a new version. Patch bump: bug fix, no API change.

## What 1.1.1 contains

Just #42 — the hosted HTTP transport now reads the bearer token from every request instead of pinning the one captured at `initialize`.

## Who this actually matters for

Anyone self-hosting the HTTP transport (`npx @churnkey/mcp --http`) from the published package.

Local stdio users were never affected: that path uses `auth: { kind: 'oauth' }` → `OAuthTokenProvider`, which refreshes internally and retries on 401. The hosted deployment at `mcp.churnkey.co` is fixed by deploying `ops/mcp/deploy-mcp.sh prod`, not by this publish.

## After merge

```bash
git checkout main && git pull
pnpm --filter @churnkey/mcp build
cd packages/mcp && npm publish
```

Note: `npm whoami` currently 401s locally — needs `npm login` first. The package has no `publishConfig.access`, so if the publish complains about a restricted scope, use `npm publish --access public` (worth adding `"publishConfig": { "access": "public" }` permanently).