### PR TITLE
fix(mcp): match the enrollment window range the API accepts (XDEV-2557)

### DIFF
--- a/packages/mcp/src/tools/abtests.ts
+++ b/packages/mcp/src/tools/abtests.ts
@@ -40,7 +40,13 @@ export function abTestTools(client: ChurnkeyClient): ToolDefinition[] {
           ])
           .optional()
           .describe('The metric the decision should hinge on. Default revenue_per_exposure.'),
-        enrollmentDays: z.number().int().min(1).max(120).optional().describe('Enrollment window (default 7 days).'),
+        enrollmentDays: z
+          .number()
+          .int()
+          .min(7)
+          .max(120)
+          .optional()
+          .describe('Enrollment window in days, 7 to 120 (default 7).'),
         trackingDays: z
           .number()
           .int()

--- a/packages/mcp/tests/tools/abtests.test.ts
+++ b/packages/mcp/tests/tools/abtests.test.ts
@@ -20,6 +20,17 @@ describe('A/B test tools', () => {
     expect(() => byName.pick_ab_test_winner.inputSchema.parse({ abTestId: 'a', winnerSegmentId: 's' })).toThrow()
   })
 
+  it('accepts only enrollment windows the API allows', () => {
+    const byName = Object.fromEntries(abTestTools(makeClient()).map((t) => [t.name, t]))
+    const create = (enrollmentDays: number) =>
+      byName.create_ab_test.inputSchema.parse({ confirm: 'create_ab_test', segmentId: 'seg1', enrollmentDays })
+
+    expect(create(7).enrollmentDays).toBe(7)
+    expect(create(120).enrollmentDays).toBe(120)
+    expect(() => create(6)).toThrow()
+    expect(() => create(121)).toThrow()
+  })
+
   it('routes winner picks with id in path and decision fields in body', async () => {
     const client = makeClient()
     const byName = Object.fromEntries(abTestTools(client).map((t) => [t.name, t]))


### PR DESCRIPTION
## Summary
`create_ab_test` declared `enrollmentDays` as `min(1).max(120)`. The API used to clamp 1..6 up to 7 silently inside the `pre('save')` hook and now rejects those values with a 422, so the tool would hand the model a server error instead of a schema error it can correct. Raise the minimum to 7 and state the accepted range in the description.

## Related PRs
- churnkey/churnkey-api#1007
- churnkey/monorepo#297

## Related Linear tickets
- [XDEV-2557](https://linear.app/churnkey/issue/XDEV-2557/cancel-flow-ab-tests-custom-enrollment-period-up-to-120-days)

## Notes
- `max(120)` already matched the new dashboard ceiling, so only the lower bound changes.
- Needs a `@churnkey/mcp` release to reach users; the API change is backwards compatible with the published 1.1.0 schema for everything except values 1..6, which now 422 instead of being clamped.

## Test plan
- [x] `npx vitest run tests/tools/abtests.test.ts` (new case: 7 and 120 accepted, 6 and 121 rejected)
- [x] `npx vitest run --root packages/mcp` (238 tests)
- [x] `npx tsc --noEmit` in `packages/mcp`
- [x] `npx biome check` on the changed files
