### PR TITLE
Land the dsr_delete removal on main

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.0.0 — 2026-08-12
+
+### Removed
+
+- **`dsr_delete`.** Erasing every record Churnkey holds for a customer is irreversible, takes effect immediately, and usually runs against a legal deadline. The confirmation literal the other destructive tools use is not a real gate here: the model writes the token itself, so it catches a malformed call but not an unwanted one. That trade is fine for a write you can undo by declining to publish it, and wrong for deleting a person's records. Right-to-erasure now runs through the Churnkey dashboard or `POST /v1/data/dsr/delete` on the Data API, where a human or a script that meant it drives the call.
+
+  `dsr_access` is unchanged. Right-to-know is a read, it is reversible, and fulfilling an Article 15 request by asking an assistant is worth keeping.
+
+- **`dsr.write` from the scopes this client requests.** With no tool that can exercise it, requesting the grant asked for authority the server would never use.
+
+  Existing grants keep the scope until the user reauthorizes; nothing in this package acts on it. Revoke and reconnect from Your MCP Sessions in account settings to drop it.
+
 ## 1.1.2 — 2026-08-11
 
 ### Changed

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @churnkey/mcp
 
-Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agents (Claude Code, Cursor, Claude Desktop, etc.) read your sessions, run analytics queries, and handle GDPR requests.
+Model Context Protocol server for [Churnkey](https://churnkey.co). Lets an AI assistant (Claude Code, Cursor, Claude Desktop, ChatGPT, etc.) read your retention data and manage cancel flows, offers, segments, and recovery campaigns.
 
 ## Tools
 
@@ -36,10 +36,11 @@ Model Context Protocol server for [Churnkey](https://churnkey.co). Lets AI agent
 | `get_dns_config` / `set_hosted_subdomain` / `add_custom_domain` / `check_domain_status` / `remove_custom_domain` | Hosted-page domain setup: read current state, set the churnkey.co subdomain (live instantly), register custom domains idempotently with the exact DNS records the customer must add on their side, poll propagation/SSL status, and deregister. Scopes `dns.read` / `dns.write`. |
 | `list_ab_tests` / `create_ab_test` / `start_ab_test` / `pause_ab_test` / `complete_ab_test` / `get_ab_test_metrics` / `pick_ab_test_winner` | Full A/B test lifecycle: clone a segment flow as the variant, edit it with the blueprint tools, start/pause, read per-arm metrics with statistical significance (n≥30 per arm), and pick the winner (commits the variant to 100% of matched traffic; early decisions need an explicit acknowledgement). Two-arm, implicit 50/50 split. Scopes `ab_test.read` / `ab_test.write`. |
 | `get_audit_log` | The workspace audit trail: every config change, publish, A/B decision, consent and MCP session read — attributed to user/source/client/scopes, with quotable summaries and before/after values. Filter by source (`mcp-oauth` = agent actions), event name, date range. Scope `account.audit_log.read` (owner/admin). |
-| `dsr_access` | GDPR/CCPA data access by email. |
-| `dsr_delete` | GDPR/CCPA data delete by email. *Destructive.* |
+| `dsr_access` | GDPR/CCPA data access by email. Erasure is not exposed as a tool — see below. |
 
-Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. DSR tools read/write the operational store directly (no lag).
+Session and recovery tools read from the Churnkey analytics warehouse — sessions refresh every ~3 hours, recoveries every ~20 minutes. `dsr_access` reads the operational store directly (no lag).
+
+**Right-to-erasure is deliberately not a tool.** The `confirm` literal that gates the other destructive tools is supplied by the model itself, so it catches a malformed call but not an unwanted one — enough for a write you can undo by declining to publish it, not enough for deleting a customer's records. Use the Churnkey dashboard or `POST /v1/data/dsr/delete` on the Data API.
 
 Blueprint edits are **granular and draft-only**: each tool mutates the unlocked working copy and sends only the targeted fields (never the full `steps` array with translations). `update_blueprint_step` handles copy + behavioral flags, `update_blueprint_offer` handles offer config, `edit_survey_structure` handles survey choices/follow-ups, and `add_blueprint_step`/`remove_blueprint_step` handle step structure. Copy edits clear stale translations for the affected content; `publish_blueprint` refreshes translations before making the draft live and is the only live-impacting blueprint action (so it's the one that requires a `confirm`).
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/mcp",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Model Context Protocol server for Churnkey. Lets an AI assistant read your retention data and manage cancel flows, offers, and recovery campaigns.",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "websiteUrl": "https://churnkey.co/feature/mcp",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/packages/mcp/src/auth/oauth.ts
+++ b/packages/mcp/src/auth/oauth.ts
@@ -28,8 +28,9 @@ export const DEFAULT_SCOPES = [
   'payment_recovery.campaigns.write',
   'account.api_usage.read',
   'account.audit_log.read',
+  // No dsr.write — no tool here can exercise it, and asking for a grant we
+  // never use is what a directory review reads as over-scoping.
   'dsr.read',
-  'dsr.write',
 ]
 
 export interface PkcePair {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,7 +5,7 @@ import { allTools } from './tools'
 import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from './tools/shared'
 
 export const SERVER_NAME = 'churnkey-mcp'
-export const SERVER_VERSION = '1.1.2'
+export const SERVER_VERSION = '2.0.0'
 
 export function createServer(config: ChurnkeyMcpConfig): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION })

--- a/packages/mcp/src/tools/dsr.ts
+++ b/packages/mcp/src/tools/dsr.ts
@@ -6,37 +6,20 @@ const accessInput = z.object({
   email: z.string().email().describe('Customer email to fetch all stored Churnkey data for.'),
 })
 
-const deleteInput = z.object({
-  email: z
-    .string()
-    .email()
-    .describe(
-      'Customer email to permanently delete from Churnkey. All sessions, feedback, and PII associated with this email are removed.',
-    ),
-})
-
+// Access only. Erasure is deliberately not a tool: the confirm literal that
+// gates our other destructive writes is typed by the model itself, which stops
+// a malformed call but not an unwanted one, and nothing here can be undone by
+// declining to publish. It stays on POST /v1/data/dsr/delete.
 export function dsrTools(client: ChurnkeyClient): ToolDefinition[] {
   return [
     {
       name: 'dsr_access',
       title: 'GDPR/CCPA data access request',
       description:
-        'Fetch every record Churnkey holds for a customer email — sessions, surveys, feedback, accepted offers. Read-only. Use to fulfill GDPR Article 15 / CCPA right-to-know requests.',
+        'Fetch every record Churnkey holds for a customer email — sessions, surveys, feedback, accepted offers. Read-only. Use to fulfill GDPR Article 15 / CCPA right-to-know requests. Deletion (Article 17 / right-to-erasure) is not available here; it runs through the Churnkey dashboard or the Data API.',
       inputSchema: accessInput,
       annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
       handler: async (args) => client.post('/data/dsr/access', { body: args }),
-    },
-    {
-      name: 'dsr_delete',
-      title: 'GDPR/CCPA data delete request',
-      description: [
-        'Permanently delete all Churnkey data for a customer email (GDPR Article 17 / CCPA right-to-delete). DESTRUCTIVE and irreversible. Always confirm the exact email with the user before invoking.',
-        '',
-        'Deletion is all-or-nothing. Check the `deleted` boolean in the response: when true, `deletedCounts` lists what was removed; when false, nothing was deleted and `reasonForRejection` explains why (e.g. the profile is too large to delete via the API — contact support). Relay `reasonForRejection` rather than reporting success. A small number of accounts have DSR disabled and return a 403 with a support-contact message.',
-      ].join('\n'),
-      inputSchema: deleteInput,
-      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
-      handler: async (args) => client.post('/data/dsr/delete', { body: args }),
     },
   ]
 }

--- a/packages/mcp/tests/auth.adversarial.test.ts
+++ b/packages/mcp/tests/auth.adversarial.test.ts
@@ -66,8 +66,12 @@ describe('oauth — buildAuthorizeUrl', () => {
 
   it('DEFAULT_SCOPES is the documented catalog', () => {
     expect(DEFAULT_SCOPES).toContain('cancel_flows.blueprints.write')
-    expect(DEFAULT_SCOPES).toContain('dsr.write')
+    expect(DEFAULT_SCOPES).toContain('dsr.read')
     expect(DEFAULT_SCOPES.length).toBeGreaterThan(20)
+  })
+
+  it('does not request erasure authority it ships no tool for', () => {
+    expect(DEFAULT_SCOPES).not.toContain('dsr.write')
   })
 })
 

--- a/packages/mcp/tests/tools/dsr.test.ts
+++ b/packages/mcp/tests/tools/dsr.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChurnkeyClient } from '../../src/client'
+import { allTools } from '../../src/tools'
+import { dsrTools } from '../../src/tools/dsr'
+
+function makeClient() {
+  return {
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+  } as unknown as ChurnkeyClient
+}
+
+describe('dsr tools', () => {
+  it('exposes right-to-know as a read, and routes it to the access endpoint', async () => {
+    const client = makeClient()
+    const [access] = dsrTools(client)
+
+    expect(access.name).toBe('dsr_access')
+    expect(access.annotations?.readOnlyHint).toBe(true)
+    expect(access.annotations?.destructiveHint).toBe(false)
+
+    await access.handler(access.inputSchema.parse({ email: 'someone@example.com' }))
+    expect(client.post).toHaveBeenCalledWith('/data/dsr/access', { body: { email: 'someone@example.com' } })
+  })
+
+  // Guards the absence, so re-adding a deletion tool has to argue past this
+  // first. Reasoning is on dsrTools in src/tools/dsr.ts.
+  it('ships no tool that erases customer data', () => {
+    const names = allTools(makeClient()).map((t) => t.name)
+    expect(names.filter((n) => n.startsWith('dsr_'))).toEqual(['dsr_access'])
+  })
+})


### PR DESCRIPTION
#46 merged into #45's branch instead of `main`, so its content never reached `main`. This lands it.

## What happened

#45 and #46 merged seven seconds apart. #46 was stacked on `mcp-directory-listing-readiness`, and GitHub retargets a stacked PR's base to `main` only once the parent merge is processed — that didn't happen inside the gap. So #46 merged into a branch that `main` had already absorbed, and the commit ended up on a dead end.

Both PRs show as merged, which is what makes it easy to miss.

## Why it needs fixing now rather than at leisure

[churnkey-docs#126](https://github.com/churnkey/churnkey-docs/pull/126) *did* merge, so `docs.churnkey.co/data-integrations/mcp` now says `dsr_delete` doesn't exist while the server still ships it. That's the documentation/server mismatch we opened the docs PR to avoid, just inverted — and the docs URL goes into both directory submissions.

`main` also still reads 1.1.2 across all three version records, so a release cut right now would ship the old tool surface under the old version.

## This PR

`caf273a` cherry-picked onto `main`, unchanged. Same nine files as the approved #46: `dsr_delete` removed, `dsr.write` dropped from the requested scopes, all three version records at 2.0.0, changelog entry, and the test covering the absence.

Verified after the pick: 57 tools, `dsr_*` filtered to exactly `['dsr_access']`, all three version records reading 2.0.0. 249 tests, clean typecheck, clean Biome.

No re-review needed on the substance — it's the diff @hookdump already approved on #46. Worth a glance at the cherry-pick itself.

## After merge

`mcp-directory-listing-readiness` still holds the orphaned merge commit and can be deleted once this lands.