### PR TITLE
Fix the registry namespace and auth method

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -48,21 +48,22 @@ jobs:
             exit 1
           fi
 
-      # The com.churnkey namespace is DNS-verified, so this authenticates with the
-      # Ed25519 private key published at churnkey.co/.well-known/mcp-registry-auth.
-      # Actions OIDC is not an option here — it only covers io.github.* namespaces.
+      # `login http` proves we own churnkey.co by fetching the Ed25519 public key
+      # from /.well-known/mcp-registry-auth and checking our signature against it.
+      # Not `login dns` — despite being the obvious-sounding fit, that one wants a
+      # TXT record and fails with "no MCP public key found in DNS TXT records".
+      # Actions OIDC is not an option: it only covers io.github.* namespaces.
       # MCP_PRIVATE_KEY is the 64-character hex seed.
-      # Skips rather than fails when the key is absent, so tagging a release
-      # before the DNS namespace is set up doesn't leave a red check on the tag.
-      # The check has to be on the env var: the secrets context is not available
-      # in a step-level `if`.
+      # Skips rather than fails when the key is absent, so a release tagged before
+      # the namespace is set up doesn't leave a red check on the tag. The check has
+      # to be on the env var: the secrets context is not available in a step-level `if`.
       - name: Publish
         env:
           MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
         run: |
           if [ -z "$MCP_PRIVATE_KEY" ]; then
-            echo "::notice::MCP_PRIVATE_KEY is not set — skipping. Set it once the com.churnkey namespace is verified."
+            echo "::notice::MCP_PRIVATE_KEY is not set — skipping."
             exit 0
           fi
-          ./mcp-publisher login dns --domain churnkey.co --private-key "$MCP_PRIVATE_KEY"
+          ./mcp-publisher login http --domain churnkey.co --private-key "$MCP_PRIVATE_KEY"
           ./mcp-publisher publish

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.churnkey/churnkey",
+  "name": "co.churnkey/churnkey",
   "description": "Read and manage Churnkey cancel flows, retention metrics, and payment recovery",
   "repository": {
     "url": "https://github.com/churnkey/sdk",


### PR DESCRIPTION
**We're live in the registry** as `co.churnkey/churnkey` 2.0.0. This makes the repo match what actually shipped, and fixes the release workflow, which would have failed on the next tag.

Both errors only surfaced when publishing for real — the workflow had never run with the key set.

## Namespace: `com.churnkey` → `co.churnkey`

The registry derives the namespace from the verified domain by reverse DNS. We verified `churnkey.co`, which grants `co.churnkey/*`. Publishing under `com.churnkey` was refused:

```
403 Forbidden — You have permission to publish: co.churnkey/*.
Attempting to publish: com.churnkey/churnkey
```

`com.churnkey` would mean verifying `churnkey.com`, which we own but which only redirects to `.co`, so there's nothing there to serve the key from. `co.churnkey` is the honest name for the domain we control.

## Auth: `login dns` → `login http`

`login dns` wants a **DNS TXT record**. Against our well-known file it fails with:

```
401 Unauthorized — no MCP public key found in DNS TXT records
```

The method that reads `https://<domain>/.well-known/mcp-registry-auth` — the file [marketing#298](https://github.com/churnkey/churnkey-marketing/pull/298) shipped — is `login http`. The naming is the trap: for a domain-verified namespace, `dns` reads like the obvious choice and isn't. The comment now says so, since the next person will reach for the same wrong one.

## Verified

Registry returns the record, `status: active`, `isLatest: true`, pointing at `https://mcp.churnkey.co/mcp`:

```
curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=churnkey"
```

The well-known file serves as `text/plain` through Cloudflare and returns 200 for a bare `Go-http-client` user agent, which is what the publisher binary sends.

## One gotcha worth knowing

`mcp-publisher publish --dry-run` **published for real.** It prints "✓ Successfully published" and the record appeared in the registry. Don't treat that flag as a safety net.

YAML validates, version-sync test still passes.