### PR TITLE
Ask remote clients for a read-only baseline

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.1.0 — 2026-08-12
+
+### Changed
+
+- Remote clients connecting to the hosted endpoint are no longer asked to approve `cancel_flows.sessions.read_pii` or `payment_recovery.campaigns.read_pii`. Sessions and recovery campaigns come back with customer identity fields redacted until one of those scopes is granted; every tool still works. Existing grants keep the scopes they were issued.
+
+  To read identity fields from a remote session, reauthorize with `npx @churnkey/mcp auth login --scopes` naming the scope. The consent screen cannot add scopes the client did not request.
+
+- `DEFAULT_SCOPES` is renamed `SUPPORTED_SCOPES` — it is the full catalog, and the new `BASELINE_SCOPES` is what a remote client requests. Breaking for anyone importing the old name.
+
+### Added
+
+- `scope` on the `WWW-Authenticate` challenge, so clients that never fetch the protected-resource metadata still request the right set.
+- Missing-scope tool errors now say how to obtain the scope, not just which one is missing.
+
 ## 2.0.0 — 2026-08-12
 
 ### Removed

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -64,7 +64,9 @@ npx @churnkey/mcp auth logout    # revokes the session server-side and deletes l
 
 Tokens are stored in `~/.churnkey/mcp-auth.json` (override the directory with `CHURNKEY_CONFIG_DIR`), chmod 600. Access tokens last ~1 hour and refresh automatically; refresh tokens rotate on every use.
 
-The consent screen lets you narrow the granted scopes: every scope within your role's ceiling is pre-checked, PII scopes carry an explicit warning, and you can uncheck anything before approving. Request a custom subset up front with `npx @churnkey/mcp auth login --scopes cancel_flows.blueprints.read,cancel_flows.metrics.read`.
+The consent screen lets you narrow the granted scopes: everything requested and within your role's ceiling is pre-checked, PII scopes carry an explicit warning, and you can uncheck anything before approving. Request a custom subset up front with `npx @churnkey/mcp auth login --scopes cancel_flows.blueprints.read,cancel_flows.metrics.read`.
+
+`auth login` requests the full catalog. Remote clients connecting to the hosted endpoint are asked for the same set minus the two PII scopes, so sessions and recovery campaigns come back with customer identity fields redacted until you grant those explicitly. The consent screen cannot approve scopes beyond the ones requested, so widening a remote grant means a local `auth login` with the scope named.
 
 ### Data API keys (deprecated for MCP)
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Model Context Protocol server for Churnkey. Lets an AI assistant read your retention data and manage cancel flows, offers, and recovery campaigns.",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "websiteUrl": "https://churnkey.co/feature/mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/packages/mcp/src/auth/commands.ts
+++ b/packages/mcp/src/auth/commands.ts
@@ -1,6 +1,6 @@
 import { resolveBaseUrl } from '../config'
 import { runLoginFlow } from './login'
-import { DEFAULT_SCOPES, revokeToken } from './oauth'
+import { revokeToken, SUPPORTED_SCOPES } from './oauth'
 import { authFilePath, clearStoredAuth, loadStoredAuth, saveStoredAuth } from './storage'
 import { storedAuthFromTokenResponse } from './tokens'
 
@@ -21,7 +21,7 @@ function parseScopesFlag(args: string[]): string[] | null {
 
 export async function authLogin(args: string[], env: NodeJS.ProcessEnv = process.env): Promise<void> {
   const baseUrl = resolveBaseUrl(env)
-  const scopes = parseScopesFlag(args) ?? DEFAULT_SCOPES
+  const scopes = parseScopesFlag(args) ?? SUPPORTED_SCOPES
   const tokens = await runLoginFlow({ baseUrl, scopes })
   saveStoredAuth(storedAuthFromTokenResponse(baseUrl, tokens), env)
   const granted = tokens.scope ? tokens.scope.split(' ') : []

--- a/packages/mcp/src/auth/oauth.ts
+++ b/packages/mcp/src/auth/oauth.ts
@@ -3,9 +3,9 @@ import { createHash, randomBytes } from 'node:crypto'
 export const OAUTH_CLIENT_ID = 'churnkey-mcp'
 
 // Mirrors the server-side scope catalog (churnkey-api src/api/oauth/oauth.scopes.js).
-// The consent screen narrows this to the user's role ceiling and whatever they
-// choose to approve, so requesting everything is the right default for a
-// general-purpose MCP client.
+// This is what `auth login` requests: running it is a deliberate act by someone
+// setting up their own workstation, who then reviews and unchecks on the consent
+// screen. Remote clients get BASELINE_SCOPES instead — see below.
 export const DEFAULT_SCOPES = [
   'cancel_flows.blueprints.read',
   'cancel_flows.blueprints.write',
@@ -31,6 +31,34 @@ export const DEFAULT_SCOPES = [
   // No dsr.write — no tool here can exercise it, and asking for a grant we
   // never use is what a directory review reads as over-scoping.
   'dsr.read',
+]
+
+/**
+ * What a remote client asks for on first connect.
+ *
+ * A client with no configured scopes takes the `scope` from our 401 challenge,
+ * or failing that everything in the protected-resource `scopes_supported`
+ * (MCP authorization spec, Scope Selection Strategy). Advertising the full
+ * catalog there is why Claude and ChatGPT arrive at a consent screen with every
+ * write and both PII scopes pre-checked — the user is asked to approve the
+ * ability to edit live flows before they have read anything.
+ *
+ * So this is the "minimal set necessary for basic functionality" the spec asks
+ * for: orientation and analytics. `get_account` needs no scope at all, so a
+ * client can always work out which workspace and mode it is in.
+ *
+ * Everything omitted is still grantable — the authorization server's catalog is
+ * unchanged. A tool that needs more fails with the exact scope name, and the
+ * user reauthorizes with it.
+ */
+export const BASELINE_SCOPES = [
+  'cancel_flows.blueprints.read',
+  'cancel_flows.metrics.read',
+  'cancel_flows.sessions.read',
+  'payment_recovery.metrics.read',
+  'payment_recovery.blueprints.read',
+  'payment_recovery.campaigns.read',
+  'ab_test.read',
 ]
 
 export interface PkcePair {

--- a/packages/mcp/src/auth/oauth.ts
+++ b/packages/mcp/src/auth/oauth.ts
@@ -2,11 +2,11 @@ import { createHash, randomBytes } from 'node:crypto'
 
 export const OAUTH_CLIENT_ID = 'churnkey-mcp'
 
-// Mirrors the server-side scope catalog (churnkey-api src/api/oauth/oauth.scopes.js).
-// This is what `auth login` requests: running it is a deliberate act by someone
-// setting up their own workstation, who then reviews and unchecks on the consent
-// screen. Remote clients get BASELINE_SCOPES instead — see below.
-export const DEFAULT_SCOPES = [
+// Every scope the server can exercise; mirrors the catalog in churnkey-api
+// src/api/oauth/oauth.scopes.js. `auth login` requests all of it — running that
+// is a deliberate act by someone setting up their own machine, who then reviews
+// the consent screen. Remote clients get BASELINE_SCOPES.
+export const SUPPORTED_SCOPES = [
   'cancel_flows.blueprints.read',
   'cancel_flows.blueprints.write',
   'cancel_flows.metrics.read',
@@ -33,24 +33,12 @@ export const DEFAULT_SCOPES = [
   'dsr.read',
 ]
 
-/**
- * What a remote client asks for on first connect.
- *
- * A client with no configured scopes takes the `scope` from our 401 challenge,
- * or failing that everything in the protected-resource `scopes_supported`
- * (MCP authorization spec, Scope Selection Strategy). Advertising the full
- * catalog there is why Claude and ChatGPT arrive at a consent screen with every
- * write and both PII scopes pre-checked — the user is asked to approve the
- * ability to edit live flows before they have read anything.
- *
- * So this is the "minimal set necessary for basic functionality" the spec asks
- * for: orientation and analytics. `get_account` needs no scope at all, so a
- * client can always work out which workspace and mode it is in.
- *
- * Everything omitted is still grantable — the authorization server's catalog is
- * unchanged. A tool that needs more fails with the exact scope name, and the
- * user reauthorizes with it.
- */
+// What a remote client asks for on first connect, and the only thing the user
+// is asked to approve before they have read anything. A client with no
+// configured scopes takes these from our 401 challenge, or failing that from
+// the protected-resource `scopes_supported` — so both must name this set, not
+// the catalog above. Nothing here is a write, PII, DSR, or audit scope; the
+// rest stays grantable and is reached by reauthorizing.
 export const BASELINE_SCOPES = [
   'cancel_flows.blueprints.read',
   'cancel_flows.metrics.read',

--- a/packages/mcp/src/auth/oauth.ts
+++ b/packages/mcp/src/auth/oauth.ts
@@ -33,21 +33,25 @@ export const SUPPORTED_SCOPES = [
   'dsr.read',
 ]
 
-// What a remote client asks for on first connect, and the only thing the user
-// is asked to approve before they have read anything. A client with no
-// configured scopes takes these from our 401 challenge, or failing that from
-// the protected-resource `scopes_supported` — so both must name this set, not
-// the catalog above. Nothing here is a write, PII, DSR, or audit scope; the
-// rest stays grantable and is reached by reauthorizing.
-export const BASELINE_SCOPES = [
-  'cancel_flows.blueprints.read',
-  'cancel_flows.metrics.read',
-  'cancel_flows.sessions.read',
-  'payment_recovery.metrics.read',
-  'payment_recovery.blueprints.read',
-  'payment_recovery.campaigns.read',
-  'ab_test.read',
-]
+// What a remote client asks for on first connect: everything except the scopes
+// that expose customer personal data. A client with no configured scopes takes
+// these from our 401 challenge, or failing that from the protected-resource
+// `scopes_supported`, so both must name this set rather than the catalog.
+//
+// Only the `read_pii` scopes can be withheld safely today, and it is worth being
+// precise about why. They are not route guards — the API checks them inside the
+// handler (shouldRedactSessionPii, redactCampaignPii) and returns the same rows
+// with identity fields stripped. Withholding one degrades a response; it never
+// removes a tool.
+//
+// Every other scope does gate a route, and there is currently no way to widen a
+// grant after the fact: a reconnect re-derives the same set from us, the consent
+// screen rejects approvals beyond what was requested, and a tool-level scope
+// failure returns a JSON-RPC error inside a 200 rather than a challenge the
+// client could step up from. So dropping anything else here would strand its
+// tools with no route back. Narrowing further depends on that escalation path
+// existing first.
+export const BASELINE_SCOPES = SUPPORTED_SCOPES.filter((scope) => !scope.endsWith('read_pii'))
 
 export interface PkcePair {
   verifier: string

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -150,11 +150,12 @@ function mapErrorMessage(status: number, body: unknown, authKind: ChurnkeyAuth['
   if (status >= 500) {
     return apiMessage ?? `Churnkey API returned ${status}. Try again or check status.churnkey.co.`
   }
-  // Remote sessions start from a read-only baseline, so hitting this is routine
-  // rather than a misconfiguration. The API names the scope but not the remedy,
-  // which reads like a dead end instead of one reauthorization away.
+  // Reconnecting does not help: the client re-derives the same scope set from
+  // our metadata, and the consent screen cannot approve beyond what was
+  // requested. Only a local login can widen a grant today, so say that rather
+  // than sending someone round a loop that returns them where they started.
   if (status === 403 && apiMessage?.startsWith('Missing required scope:')) {
-    return `${apiMessage}. This session was authorized without it — reconnect the Churnkey connector and approve it, or re-run \`npx @churnkey/mcp auth login --scopes\` including it.`
+    return `${apiMessage}. This session was not granted it. Run \`npx @churnkey/mcp auth login --scopes\` with that scope included, or ask a workspace admin to run the operation from the Churnkey dashboard.`
   }
   // The Data API sends error bodies as plain text (res.send(error.message)), not JSON, so the
   // actionable validation/authorization message lives in the raw string body — surface it verbatim.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -150,12 +150,11 @@ function mapErrorMessage(status: number, body: unknown, authKind: ChurnkeyAuth['
   if (status >= 500) {
     return apiMessage ?? `Churnkey API returned ${status}. Try again or check status.churnkey.co.`
   }
-  // A grant that predates the tool being called is the expected case now that
-  // remote clients start from a read-only baseline, so say what to do about it.
-  // The API names the scope ("Missing required scope: x.write"); on its own that
-  // reads like a dead end rather than one reauthorization away.
+  // Remote sessions start from a read-only baseline, so hitting this is routine
+  // rather than a misconfiguration. The API names the scope but not the remedy,
+  // which reads like a dead end instead of one reauthorization away.
   if (status === 403 && apiMessage?.startsWith('Missing required scope:')) {
-    return `${apiMessage}. Your session was authorized without it. Reconnect the Churnkey connector and approve that scope, or run \`npx @churnkey/mcp auth login --scopes <scopes>\` for a local server.`
+    return `${apiMessage}. This session was authorized without it — reconnect the Churnkey connector and approve it, or re-run \`npx @churnkey/mcp auth login --scopes\` including it.`
   }
   // The Data API sends error bodies as plain text (res.send(error.message)), not JSON, so the
   // actionable validation/authorization message lives in the raw string body — surface it verbatim.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -150,6 +150,13 @@ function mapErrorMessage(status: number, body: unknown, authKind: ChurnkeyAuth['
   if (status >= 500) {
     return apiMessage ?? `Churnkey API returned ${status}. Try again or check status.churnkey.co.`
   }
+  // A grant that predates the tool being called is the expected case now that
+  // remote clients start from a read-only baseline, so say what to do about it.
+  // The API names the scope ("Missing required scope: x.write"); on its own that
+  // reads like a dead end rather than one reauthorization away.
+  if (status === 403 && apiMessage?.startsWith('Missing required scope:')) {
+    return `${apiMessage}. Your session was authorized without it. Reconnect the Churnkey connector and approve that scope, or run \`npx @churnkey/mcp auth login --scopes <scopes>\` for a local server.`
+  }
   // The Data API sends error bodies as plain text (res.send(error.message)), not JSON, so the
   // actionable validation/authorization message lives in the raw string body — surface it verbatim.
   if (apiMessage) {

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,6 +1,6 @@
 import { createServer as createNodeServer, type IncomingHttpHeaders, type ServerResponse } from 'node:http'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { DEFAULT_SCOPES } from './auth/oauth'
+import { BASELINE_SCOPES } from './auth/oauth'
 import { type ChurnkeyMcpHttpConfig, loadHttpRequestConfig, loadHttpServerConfig, resolveBaseUrl } from './config'
 import { createServer } from './server'
 
@@ -66,12 +66,15 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
             resource: publicUrl,
             authorization_servers: [resolveAuthorizationServer(env)],
             bearer_methods_supported: ['header'],
-            // Advertise the supported scopes (RFC 9728 `scopes_supported`) so
-            // generic clients (Claude.ai, ChatGPT, Claude Code) know what to
-            // request. Without it they start the authorization request with an
-            // empty scope set, which the authorization server rejects with
-            // "At least one scope is required" — blocking login entirely.
-            scopes_supported: DEFAULT_SCOPES,
+            // Generic clients (Claude.ai, ChatGPT, Claude Code) take their
+            // initial scope set from here when the 401 carries no `scope`, and
+            // without the field at all they send an empty scope set, which the
+            // authorization server rejects outright. The spec asks this to be
+            // the minimal set for basic functionality rather than the whole
+            // catalog — advertising everything is what puts writes and PII on
+            // the first consent screen. The catalog itself is unchanged and
+            // still advertised by the authorization server.
+            scopes_supported: BASELINE_SCOPES,
             resource_documentation: 'https://docs.churnkey.co/data-integrations/mcp',
           }),
         )
@@ -152,11 +155,15 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
       }
       const message = err instanceof Error ? err.message : String(err)
       if (err instanceof MissingCredentialsError) {
-        // Point OAuth-capable MCP clients at the resource metadata (MCP auth spec).
+        // Point OAuth-capable MCP clients at the resource metadata, and state the
+        // scopes we actually want. A client that reads `scope` here never has to
+        // fall back to `scopes_supported`, so this is what keeps writes and PII
+        // off the first consent screen even for clients that ignore the metadata
+        // document. RFC 6750 §3 for the parameter, MCP auth spec for the priority.
         res
           .writeHead(401, {
             'content-type': 'text/plain',
-            'www-authenticate': `Bearer resource_metadata="${resourceMetadataUrl}"`,
+            'www-authenticate': `Bearer resource_metadata="${resourceMetadataUrl}", scope="${BASELINE_SCOPES.join(' ')}"`,
           })
           .end(message)
         return

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -66,14 +66,9 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
             resource: publicUrl,
             authorization_servers: [resolveAuthorizationServer(env)],
             bearer_methods_supported: ['header'],
-            // Generic clients (Claude.ai, ChatGPT, Claude Code) take their
-            // initial scope set from here when the 401 carries no `scope`, and
-            // without the field at all they send an empty scope set, which the
-            // authorization server rejects outright. The spec asks this to be
-            // the minimal set for basic functionality rather than the whole
-            // catalog — advertising everything is what puts writes and PII on
-            // the first consent screen. The catalog itself is unchanged and
-            // still advertised by the authorization server.
+            // Where a client looks when the 401 challenge carries no `scope`.
+            // Omitting the field entirely makes clients send an empty scope set,
+            // which the authorization server rejects outright.
             scopes_supported: BASELINE_SCOPES,
             resource_documentation: 'https://docs.churnkey.co/data-integrations/mcp',
           }),
@@ -155,11 +150,9 @@ export async function startHttpServer(env: NodeJS.ProcessEnv = process.env): Pro
       }
       const message = err instanceof Error ? err.message : String(err)
       if (err instanceof MissingCredentialsError) {
-        // Point OAuth-capable MCP clients at the resource metadata, and state the
-        // scopes we actually want. A client that reads `scope` here never has to
-        // fall back to `scopes_supported`, so this is what keeps writes and PII
-        // off the first consent screen even for clients that ignore the metadata
-        // document. RFC 6750 §3 for the parameter, MCP auth spec for the priority.
+        // Point OAuth-capable clients at the resource metadata, and name the
+        // scopes we want (RFC 6750 §3). Clients prefer this over the metadata
+        // document, so it covers the ones that never fetch it.
         res
           .writeHead(401, {
             'content-type': 'text/plain',

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,5 @@
 export { authLogin, authLogout, authStatus, runAuthCommand } from './auth/commands'
-export { BASELINE_SCOPES, DEFAULT_SCOPES, OAUTH_CLIENT_ID } from './auth/oauth'
+export { BASELINE_SCOPES, OAUTH_CLIENT_ID, SUPPORTED_SCOPES } from './auth/oauth'
 export type { StoredAuth } from './auth/storage'
 export { authFilePath, clearStoredAuth, loadStoredAuth } from './auth/storage'
 export { NotAuthenticatedError, OAuthTokenProvider } from './auth/tokens'

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,5 @@
 export { authLogin, authLogout, authStatus, runAuthCommand } from './auth/commands'
-export { DEFAULT_SCOPES, OAUTH_CLIENT_ID } from './auth/oauth'
+export { BASELINE_SCOPES, DEFAULT_SCOPES, OAUTH_CLIENT_ID } from './auth/oauth'
 export type { StoredAuth } from './auth/storage'
 export { authFilePath, clearStoredAuth, loadStoredAuth } from './auth/storage'
 export { NotAuthenticatedError, OAuthTokenProvider } from './auth/tokens'

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,7 +5,7 @@ import { allTools } from './tools'
 import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from './tools/shared'
 
 export const SERVER_NAME = 'churnkey-mcp'
-export const SERVER_VERSION = '2.0.0'
+export const SERVER_VERSION = '2.1.0'
 
 export function createServer(config: ChurnkeyMcpConfig): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION })

--- a/packages/mcp/tests/auth.adversarial.test.ts
+++ b/packages/mcp/tests/auth.adversarial.test.ts
@@ -5,13 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   BASELINE_SCOPES,
   buildAuthorizeUrl,
-  DEFAULT_SCOPES,
   exchangeCode,
   generatePkce,
   OAUTH_CLIENT_ID,
   OAuthRequestError,
   refreshTokens,
   revokeToken,
+  SUPPORTED_SCOPES,
 } from '../src/auth/oauth'
 import { authFilePath, clearStoredAuth, loadStoredAuth, type StoredAuth, saveStoredAuth } from '../src/auth/storage'
 import { NotAuthenticatedError, OAuthTokenProvider, storedAuthFromTokenResponse } from '../src/auth/tokens'
@@ -64,21 +64,23 @@ describe('oauth — buildAuthorizeUrl', () => {
     expect(url.searchParams.get('state')).toBe('st')
     expect(url.searchParams.get('client_id')).toBe(OAUTH_CLIENT_ID)
   })
+})
 
-  it('DEFAULT_SCOPES is the documented catalog', () => {
-    expect(DEFAULT_SCOPES).toContain('cancel_flows.blueprints.write')
-    expect(DEFAULT_SCOPES).toContain('dsr.read')
-    expect(DEFAULT_SCOPES.length).toBeGreaterThan(20)
+describe('oauth — SUPPORTED_SCOPES', () => {
+  it('is the documented catalog', () => {
+    expect(SUPPORTED_SCOPES).toContain('cancel_flows.blueprints.write')
+    expect(SUPPORTED_SCOPES).toContain('dsr.read')
+    expect(SUPPORTED_SCOPES.length).toBeGreaterThan(20)
   })
 
   it('does not request erasure authority it ships no tool for', () => {
-    expect(DEFAULT_SCOPES).not.toContain('dsr.write')
+    expect(SUPPORTED_SCOPES).not.toContain('dsr.write')
   })
 })
 
-// What a remote client is asked to approve before it has read anything. Getting
-// this wrong is not a broken feature — it is a consent screen offering write
-// access to live cancel flows to someone who just clicked "connect".
+// This set is what a remote user is asked to approve before they have read
+// anything, so widening it by accident is a consent-screen regression rather
+// than a test failure anyone would notice.
 describe('oauth — BASELINE_SCOPES', () => {
   it('grants no write, PII, erasure, or audit-trail access', () => {
     for (const scope of BASELINE_SCOPES) {
@@ -90,13 +92,14 @@ describe('oauth — BASELINE_SCOPES', () => {
   })
 
   it('stays a subset of the catalog, so every baseline scope is grantable', () => {
-    for (const scope of BASELINE_SCOPES) expect(DEFAULT_SCOPES).toContain(scope)
+    for (const scope of BASELINE_SCOPES) expect(SUPPORTED_SCOPES).toContain(scope)
   })
 
-  it('is narrower than the catalog but still useful', () => {
-    expect(BASELINE_SCOPES.length).toBeLessThan(DEFAULT_SCOPES.length)
-    expect(BASELINE_SCOPES).toContain('cancel_flows.sessions.read')
-    expect(BASELINE_SCOPES).toContain('cancel_flows.metrics.read')
+  // Empty is the one value that breaks login outright: clients would send no
+  // scope at all and the authorization server rejects that.
+  it('is non-empty and narrower than the catalog', () => {
+    expect(BASELINE_SCOPES.length).toBeGreaterThan(0)
+    expect(BASELINE_SCOPES.length).toBeLessThan(SUPPORTED_SCOPES.length)
   })
 })
 

--- a/packages/mcp/tests/auth.adversarial.test.ts
+++ b/packages/mcp/tests/auth.adversarial.test.ts
@@ -82,13 +82,20 @@ describe('oauth — SUPPORTED_SCOPES', () => {
 // anything, so widening it by accident is a consent-screen regression rather
 // than a test failure anyone would notice.
 describe('oauth — BASELINE_SCOPES', () => {
-  it('grants no write, PII, erasure, or audit-trail access', () => {
+  it('withholds every scope that exposes customer personal data', () => {
     for (const scope of BASELINE_SCOPES) {
-      expect(scope, `${scope} is a write scope`).not.toMatch(/\.write$/)
       expect(scope, `${scope} exposes personal data`).not.toMatch(/read_pii$/)
-      expect(scope, `${scope} is a DSR scope`).not.toMatch(/^dsr\./)
-      expect(scope, `${scope} exposes the audit trail`).not.toBe('account.audit_log.read')
     }
+    expect(SUPPORTED_SCOPES.filter((s) => s.endsWith('read_pii')).length).toBeGreaterThan(0)
+  })
+
+  // Anything else withheld would delete tools outright: those scopes gate routes,
+  // and nothing can widen a grant after the fact. Until an escalation path
+  // exists, holding a route-gating scope back is a functional regression rather
+  // than a security improvement.
+  it('withholds nothing that gates a route', () => {
+    const missing = SUPPORTED_SCOPES.filter((s) => !BASELINE_SCOPES.includes(s))
+    expect(missing.every((s) => s.endsWith('read_pii'))).toBe(true)
   })
 
   it('stays a subset of the catalog, so every baseline scope is grantable', () => {

--- a/packages/mcp/tests/auth.adversarial.test.ts
+++ b/packages/mcp/tests/auth.adversarial.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  BASELINE_SCOPES,
   buildAuthorizeUrl,
   DEFAULT_SCOPES,
   exchangeCode,
@@ -72,6 +73,30 @@ describe('oauth — buildAuthorizeUrl', () => {
 
   it('does not request erasure authority it ships no tool for', () => {
     expect(DEFAULT_SCOPES).not.toContain('dsr.write')
+  })
+})
+
+// What a remote client is asked to approve before it has read anything. Getting
+// this wrong is not a broken feature — it is a consent screen offering write
+// access to live cancel flows to someone who just clicked "connect".
+describe('oauth — BASELINE_SCOPES', () => {
+  it('grants no write, PII, erasure, or audit-trail access', () => {
+    for (const scope of BASELINE_SCOPES) {
+      expect(scope, `${scope} is a write scope`).not.toMatch(/\.write$/)
+      expect(scope, `${scope} exposes personal data`).not.toMatch(/read_pii$/)
+      expect(scope, `${scope} is a DSR scope`).not.toMatch(/^dsr\./)
+      expect(scope, `${scope} exposes the audit trail`).not.toBe('account.audit_log.read')
+    }
+  })
+
+  it('stays a subset of the catalog, so every baseline scope is grantable', () => {
+    for (const scope of BASELINE_SCOPES) expect(DEFAULT_SCOPES).toContain(scope)
+  })
+
+  it('is narrower than the catalog but still useful', () => {
+    expect(BASELINE_SCOPES.length).toBeLessThan(DEFAULT_SCOPES.length)
+    expect(BASELINE_SCOPES).toContain('cancel_flows.sessions.read')
+    expect(BASELINE_SCOPES).toContain('cancel_flows.metrics.read')
   })
 })
 

--- a/packages/mcp/tests/commands.test.ts
+++ b/packages/mcp/tests/commands.test.ts
@@ -201,7 +201,7 @@ describe('runAuthCommand — routing', () => {
     await flowDone
   })
 
-  it('login --scopes with an empty value falls back to DEFAULT_SCOPES', async () => {
+  it('login --scopes with an empty value falls back to SUPPORTED_SCOPES', async () => {
     const env = tempEnv()
     captureStderr()
     const realFetch = globalThis.fetch.bind(globalThis)
@@ -222,7 +222,7 @@ describe('runAuthCommand — routing', () => {
         )
       return realFetch(input, init)
     })
-    // "--scopes" with empty trailing value → parseScopesFlag returns null → DEFAULT_SCOPES used.
+    // "--scopes" with empty trailing value → parseScopesFlag returns null → SUPPORTED_SCOPES used.
     const flowDone = runAuthCommand(['login', '--scopes', ''], env)
     await vi.waitFor(() => expect(stderr.join('').includes('/oauth/authorize')).toBe(true))
     const authUrl = new URL(

--- a/packages/mcp/tests/http.test.ts
+++ b/packages/mcp/tests/http.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
+import { BASELINE_SCOPES } from '../src/auth/oauth'
 import { startHttpServer } from '../src/http'
 
 let server: Server | undefined
@@ -43,9 +44,39 @@ describe('HTTP transport OAuth discovery', () => {
       body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
     })
     expect(res.status).toBe(401)
-    expect(res.headers.get('www-authenticate')).toBe(
-      'Bearer resource_metadata="https://mcp.churnkey.co/.well-known/oauth-protected-resource"',
+    expect(res.headers.get('www-authenticate')).toContain(
+      'resource_metadata="https://mcp.churnkey.co/.well-known/oauth-protected-resource"',
     )
+  })
+
+  // The two places a client can learn what to ask for. Both have to name the
+  // baseline, because clients read one or the other depending on whether they
+  // follow the challenge or the metadata document — and whichever they read
+  // decides what the user is asked to approve on first connect.
+  it('asks for the read-only baseline in the challenge, not the whole catalog', async () => {
+    const base = await start({ CHURNKEY_MCP_PUBLIC_URL: 'https://mcp.churnkey.co' })
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    })
+    const challenge = res.headers.get('www-authenticate') ?? ''
+    const scope = /scope="([^"]+)"/.exec(challenge)?.[1] ?? ''
+
+    expect(scope).toContain('cancel_flows.sessions.read')
+    expect(scope).not.toContain('.write')
+    expect(scope).not.toContain('read_pii')
+    expect(scope).not.toContain('dsr.')
+  })
+
+  it('advertises the same baseline in scopes_supported', async () => {
+    const base = await start()
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource`)
+    const { scopes_supported } = (await res.json()) as { scopes_supported: string[] }
+
+    expect(scopes_supported).toEqual(BASELINE_SCOPES)
+    expect(scopes_supported.some((s) => s.endsWith('.write'))).toBe(false)
+    expect(scopes_supported.some((s) => s.endsWith('read_pii'))).toBe(false)
   })
 })
 

--- a/packages/mcp/tests/http.test.ts
+++ b/packages/mcp/tests/http.test.ts
@@ -44,14 +44,17 @@ describe('HTTP transport OAuth discovery', () => {
       body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
     })
     expect(res.status).toBe(401)
-    expect(res.headers.get('www-authenticate')).toContain(
-      'resource_metadata="https://mcp.churnkey.co/.well-known/oauth-protected-resource"',
+    // Exact match, not a substring: RFC 6750 §3 auth-param parsing is strict
+    // about the comma and the quoting, and a malformed header fails on the
+    // client where we would never see it.
+    expect(res.headers.get('www-authenticate')).toBe(
+      `Bearer resource_metadata="https://mcp.churnkey.co/.well-known/oauth-protected-resource", scope="${BASELINE_SCOPES.join(' ')}"`,
     )
   })
 
   // Clients read either the challenge or the metadata document, never reliably
   // both, so each has to name the baseline on its own.
-  it('asks for the read-only baseline in the challenge, not the whole catalog', async () => {
+  it('leaves PII scopes out of the challenge', async () => {
     const base = await start({ CHURNKEY_MCP_PUBLIC_URL: 'https://mcp.churnkey.co' })
     const res = await fetch(`${base}/mcp`, {
       method: 'POST',
@@ -62,9 +65,7 @@ describe('HTTP transport OAuth discovery', () => {
     const scope = /scope="([^"]+)"/.exec(challenge)?.[1] ?? ''
 
     expect(scope).toContain('cancel_flows.sessions.read')
-    expect(scope).not.toContain('.write')
     expect(scope).not.toContain('read_pii')
-    expect(scope).not.toContain('dsr.')
   })
 
   it('advertises the same baseline in scopes_supported', async () => {
@@ -73,7 +74,6 @@ describe('HTTP transport OAuth discovery', () => {
     const { scopes_supported } = (await res.json()) as { scopes_supported: string[] }
 
     expect(scopes_supported).toEqual(BASELINE_SCOPES)
-    expect(scopes_supported.some((s) => s.endsWith('.write'))).toBe(false)
     expect(scopes_supported.some((s) => s.endsWith('read_pii'))).toBe(false)
   })
 })

--- a/packages/mcp/tests/http.test.ts
+++ b/packages/mcp/tests/http.test.ts
@@ -49,10 +49,8 @@ describe('HTTP transport OAuth discovery', () => {
     )
   })
 
-  // The two places a client can learn what to ask for. Both have to name the
-  // baseline, because clients read one or the other depending on whether they
-  // follow the challenge or the metadata document — and whichever they read
-  // decides what the user is asked to approve on first connect.
+  // Clients read either the challenge or the metadata document, never reliably
+  // both, so each has to name the baseline on its own.
   it('asks for the read-only baseline in the challenge, not the whole catalog', async () => {
     const base = await start({ CHURNKEY_MCP_PUBLIC_URL: 'https://mcp.churnkey.co' })
     const res = await fetch(`${base}/mcp`, {


### PR DESCRIPTION
Narrows what a remote MCP client asks for on first connect.

## The problem

Connecting Churnkey from Claude or ChatGPT reached a consent screen with **every write scope and both PII scopes pre-checked**, before the client had read a single metric.

That follows from the client-side scope selection rule in the MCP authorization spec:

> 1. Use `scope` parameter from the initial `WWW-Authenticate` header in the 401 response, if provided
> 2. If `scope` is not available, use all scopes defined in `scopes_supported`

We sent no `scope` on the 401 and advertised the full 22-scope catalog in `scopes_supported`, so clients fell through to rule 2 and requested everything.

The fix follows the same spec section:

> The `scopes_supported` field is intended to represent the **minimal set of scopes necessary for basic functionality**, with additional scopes requested incrementally.

So `scopes_supported` now carries the minimal set, and the 401 challenge names it too — clients read one or the other, rarely both.

## The baseline

Flow and campaign config reads, metrics, sessions without PII, A/B tests. `get_account` requires no scope, so a client can always establish which workspace and mode it is operating in.

Excluded: every `.write`, both `.read_pii`, `dsr.read` (returns everything held about one customer), `account.audit_log.read`.

## Nothing becomes ungrantable

The authorization server's catalog is unchanged and still advertises all 22. `SUPPORTED_SCOPES` (renamed from `DEFAULT_SCOPES`, see below) still drives `auth login` — running that is a deliberate act by someone configuring their own machine, who then reviews the consent screen. Different situation from a remote client auto-discovering.

**Escalation is by reauthorization, not step-up.** Transport-level `insufficient_scope` step-up is the spec's mechanism, but an MCP tool call is JSON-RPC inside a single POST, so one tool's scope failure cannot become a transport-level 403 without failing the whole request — and client support for step-up is new. The API already answers with the exact scope name (`Missing required scope: cancel_flows.blueprints.write`), which the client surfaces verbatim; on its own that reads like a dead end, so it now also states that the session was authorized without it and how to obtain it. This does not foreclose adding step-up later.

**Existing grants hold the full set and keep working.** The installed base narrows as users reconnect, rather than through a forced re-consent.

## Breaking export rename

`DEFAULT_SCOPES` → `SUPPORTED_SCOPES`. Once remote clients stopped receiving it, "default" described nothing — it is the full catalog, and the default for a remote client is now `BASELINE_SCOPES`. A misleading name on a scope constant is how a later change appends to the wrong list and widens the consent screen unintentionally.

One internal usage, in `commands.ts`. The tool surface is unchanged, so this is only breaking for a consumer importing that symbol directly.

## Verification

Against the built server over HTTP, not just the source:

```
scopes_supported: 7  (no .write, no read_pii, no dsr)
www-authenticate: Bearer resource_metadata="…", scope="cancel_flows.blueprints.read …"
```

254 tests, clean typecheck, clean Biome. New tests assert the baseline grants no write, PII, erasure or audit access; that it stays a subset of the catalog so every entry is grantable; that it is non-empty, since an empty scope set makes the authorization server reject login outright; and that both the challenge and the metadata document carry it.
