### PR TITLE
Send identity metadata in the initialize response

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -7,8 +7,24 @@ import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from './tools/shared'
 export const SERVER_NAME = 'churnkey-mcp'
 export const SERVER_VERSION = '2.1.0'
 
+// Directories build their listing from whatever `initialize` returns. Sending
+// only name and version is why Smithery rendered us as a lowercase "churnkey"
+// with an empty description — there was nothing else to read. Every crawler
+// that scans the endpoint reads the same fields, so this is the one place to
+// fix it rather than per-directory.
+const SERVER_TITLE = 'Churnkey'
+const SERVER_DESCRIPTION =
+  'Read Churnkey retention data and manage cancel flows, offers, segments, and payment recovery campaigns.'
+const SERVER_WEBSITE = 'https://churnkey.co/feature/mcp'
+
 export function createServer(config: ChurnkeyMcpConfig): McpServer {
-  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION })
+  const server = new McpServer({
+    name: SERVER_NAME,
+    title: SERVER_TITLE,
+    version: SERVER_VERSION,
+    description: SERVER_DESCRIPTION,
+    websiteUrl: SERVER_WEBSITE,
+  })
   const client = new ChurnkeyClient(config)
 
   for (const tool of allTools(client)) {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -45,6 +45,8 @@ vi.mock('../src/tools', () => ({
 }))
 
 import { readFileSync } from 'node:fs'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import type { ChurnkeyClient } from '../src/client'
 import { createServer, SERVER_NAME, SERVER_VERSION } from '../src/server'
 import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from '../src/tools/shared'
@@ -81,6 +83,23 @@ afterEach(() => {
 describe('server metadata', () => {
   it('exposes a stable name', () => {
     expect(SERVER_NAME).toBe('churnkey-mcp')
+  })
+
+  // Directories build their listing from what `initialize` returns. Losing a
+  // field breaks nothing we can see — it surfaces as a blank description on
+  // someone else's site, which is how Smithery first rendered us. Asserted
+  // through a real handshake rather than the server's internals, since what
+  // matters is what a client receives.
+  it('sends the identity fields a directory renders', async () => {
+    const [clientSide, serverSide] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'test', version: '0' }, { capabilities: {} })
+    await Promise.all([createServer(config).connect(serverSide), client.connect(clientSide)])
+
+    const info = client.getServerVersion()
+    expect(info?.title).toBe('Churnkey')
+    expect(info?.description).toBeTruthy()
+    expect(info?.websiteUrl).toMatch(/^https:\/\//)
+    await client.close()
   })
 
   // A release has to move three version records together: npm, what the server


### PR DESCRIPTION
Found while completing the Smithery listing. The server is live there with all 57 tools, but renders as a lowercase **churnkey** with an empty description.

## Why

Directories build their listing from whatever `initialize` returns. Ours returned:

```json
{ "name": "churnkey-mcp", "version": "2.1.0" }
```

That's everything a crawler had to work with, so an empty description was the only possible outcome. The SDK's `Implementation` schema already carries `title`, `description`, `websiteUrl` and `icons` — we were sending none of them.

Fixing it here rather than in each directory's own metadata form means Glama, PulseMCP, mcp.so and both directory scans pick it up on their next crawl, instead of four places to keep in sync.

Now:

```json
{
  "name": "churnkey-mcp",
  "title": "Churnkey",
  "version": "2.1.0",
  "websiteUrl": "https://churnkey.co/feature/mcp",
  "description": "Read Churnkey retention data and manage cancel flows, offers, segments, and payment recovery campaigns."
}
```

`icons` is deliberately omitted — there is no square logo yet, and a broken `src` is worse than an absent field. Worth adding when one exists, since it would feed every directory the same way.

## Not a bug: the resources/prompts warnings

Smithery's scan also logged `Failed to list resources: MCP error -32601` and the same for prompts. Checked, and that's correct on both sides — we declare `{"tools":{"listChanged":true}}` and nothing else, register no resources or prompts, so `Method not found` is the right answer to a probe. No change needed.

## Testing

Through a real handshake over a linked in-memory transport rather than reading the server's internals, since what matters is what a client actually receives. Verified it fails when a field is dropped — removing `title` gives `expected undefined to be 'Churnkey'`.

256 tests, clean typecheck, clean Biome.