### PR TITLE
Release 2.2.0

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 2.2.0 — 2026-08-13
+
+### Added
+
+- The `initialize` response now carries `title`, `description` and `websiteUrl` alongside name and version. Directories build their listing from these, and sending only name and version is why Smithery rendered the server as a lowercase "churnkey" with no description. Every crawler that scans the endpoint reads the same fields, so this fixes the listing everywhere rather than in each directory's own form.
+
+  No icon yet — a broken `src` would be worse than an absent field.
+
 ## 2.1.0 — 2026-08-12
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@churnkey/mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Model Context Protocol server for Churnkey. Lets an AI assistant read your retention data and manage cancel flows, offers, and recovery campaigns.",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "websiteUrl": "https://churnkey.co/feature/mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,7 +5,7 @@ import { allTools } from './tools'
 import { MODE_DATA_NOTE, MODE_TRAFFIC_NOTE } from './tools/shared'
 
 export const SERVER_NAME = 'churnkey-mcp'
-export const SERVER_VERSION = '2.1.0'
+export const SERVER_VERSION = '2.2.0'
 
 // Directories build their listing from whatever `initialize` returns. Sending
 // only name and version is why Smithery rendered us as a lowercase "churnkey"


### PR DESCRIPTION
Version bump for the identity metadata from #50, which merged without one.

## Why this can't just be deployed

`main` currently carries the metadata change but is still stamped `2.1.0`, and npm's published `2.1.0` does not have it. Deploying as-is would put a server in production that reports `"version": "2.1.0"` in its `initialize` response while behaving differently from the `2.1.0` anyone can install.

The version a server reports is the first thing someone checks when a directory listing looks wrong, so having two different artifacts answer with the same number is worth avoiding.

Additive change — new optional fields in the handshake, no behaviour removed — so minor.

Moves all three records together: `package.json`, `server.json`, `SERVER_VERSION`. The sync test enforces that.

## Release order once merged

1. Deploy dev, verify the handshake carries `title` / `description` / `websiteUrl`
2. Deploy prod
3. `npm publish`
4. Tag `@churnkey/mcp@2.2.0` — this is what updates the official registry record, which is otherwise left advertising the old version
5. Republish to Smithery so it re-scans and picks up the new metadata

256 tests, clean typecheck, clean Biome.