### PR TITLE
Drop the unimplemented campaign types from list_recovery_blueprints

### DIFF
--- a/packages/mcp/src/tools/payment-recovery.ts
+++ b/packages/mcp/src/tools/payment-recovery.ts
@@ -124,13 +124,10 @@ export function paymentRecoveryTools(client: ChurnkeyClient): ToolDefinition[] {
       name: 'list_recovery_blueprints',
       title: 'List payment recovery campaign configs',
       description:
-        "List the org's payment recovery (dunning) campaign configurations: name, type (DELINQUENCY/RENEWAL/EXPIRATION), schedule, enabled state, email/SMS counts. These are the templates that spawn per-customer sequences — also the template library: clone one as a starting point.",
-      inputSchema: z.object({
-        campaignType: z.enum(['DELINQUENCY', 'RENEWAL', 'EXPIRATION']).optional().describe('Defaults to DELINQUENCY.'),
-      }),
+        "List the org's payment recovery (dunning) campaign configurations: name, schedule, enabled state, email/SMS counts. These are the templates that spawn per-customer sequences — also the template library: clone one as a starting point.",
+      inputSchema: z.object({}),
       annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
-      handler: async (args) =>
-        client.get('/data/payment-recovery/blueprints', { query: args as Record<string, unknown> }),
+      handler: async () => client.get('/data/payment-recovery/blueprints'),
     },
     {
       name: 'get_recovery_blueprint',

--- a/packages/mcp/tests/tools/payment-recovery.test.ts
+++ b/packages/mcp/tests/tools/payment-recovery.test.ts
@@ -27,6 +27,15 @@ describe('payment recovery tools', () => {
     expect(() => byName.stop_recovery_campaign.inputSchema.parse({ campaignId: 'c1' })).toThrow()
   })
 
+  it('lists blueprints with no arguments', async () => {
+    const client = makeClient()
+    const byName = Object.fromEntries(paymentRecoveryTools(client).map((t) => [t.name, t]))
+
+    expect(Object.keys(byName.list_recovery_blueprints.inputSchema.shape)).toEqual([])
+    await byName.list_recovery_blueprints.handler({})
+    expect(client.get).toHaveBeenCalledWith('/data/payment-recovery/blueprints')
+  })
+
   it('routes email edits with ids in the path and updates in the body', async () => {
     const client = makeClient()
     const byName = Object.fromEntries(paymentRecoveryTools(client).map((t) => [t.name, t]))


### PR DESCRIPTION
## What

`list_recovery_blueprints` advertised

```ts
campaignType: z.enum(['DELINQUENCY', 'RENEWAL', 'EXPIRATION']).optional()
```

and described the results as `type (DELINQUENCY/RENEWAL/EXPIRATION)`. That enum was copied from `CAMPAIGN_TYPE` in `churnkey-api` (`src/helpers/shared.js`), which lists four members. Two of them are dead:

- **`RENEWAL` / `EXPIRATION`** — nothing anywhere in `churnkey-api` creates, reads or dispatches a campaign of either type. The only references are the enum declarations themselves (`src/helpers/shared.js`, `src/v2/Campaign/model/index.ts`) and the one guard in `publicListRecoveryBlueprints` that lets them through. Passing either returned `[]`, every time.
- **`REACTIVATION`** — a real product, but not served by this endpoint: `/data/payment-recovery/blueprints` rejects it with a 422. Reactivation lives on its own internal routes (`src/api/reactivation/*`) with no Data API surface.

So `DELINQUENCY` was the only value that ever returned anything, and it was already the default.

The cost of leaving it wasn't a broken call — it was a wrong map. An agent that reads the schema concludes Churnkey runs three kinds of recovery campaign, then goes hunting for the renewal ones.

## The change

- Removed `RENEWAL` and `EXPIRATION`, and with them the `campaignType` parameter — one legal value that equals the default isn't a filter. `list_recovery_blueprints` now takes no arguments.
- Dropped the stale type list from the description.
- Left a comment recording why the parameter is absent, so the next person reading `CAMPAIGN_TYPE` in the API doesn't mirror it back in.
- Test asserting the tool has an empty input schema and sends no query.

## Compatibility

Not breaking. `inputSchema` is a `z.object`, which strips unknown keys, so a client still sending `campaignType` gets it dropped and the endpoint applies its `DELINQUENCY` default — the same list it was already returning for every legal value.

## Not in scope

- Exposing reactivation campaigns over MCP. That needs the API to serve them first.
- Removing `RENEWAL`/`EXPIRATION` from the four repos that also declare them. Those are up separately, and the production check they needed came back clean — across 14,039,578 campaigns and 8,499 blueprints there is not one document of either type:
  - [churnkey/churnkey-api#1042](https://github.com/churnkey/churnkey-api/pull/1042) — the source enum + the Data API guard
  - [churnkey/churnkey-webhooks#174](https://github.com/churnkey/churnkey-webhooks/pull/174)
  - [churnkey/churnkey-dunning#92](https://github.com/churnkey/churnkey-dunning/pull/92)
  - [churnkey/monorepo#313](https://github.com/churnkey/monorepo/pull/313) — including two dead UI branches rendering "Expiration" / "Renewal" labels

  **No ordering between any of them, this PR included.** With no documents of either type, no repo's enum has to lead.

## Docs

Checked — none needed. `churnkey-docs` describes `list_recovery_blueprints` at the tool level (`content/6.data-integrations/5.mcp.md`) and never names `campaignType`, `RENEWAL` or `EXPIRATION`; the Data API page doesn't cover the `/v1/data/payment-recovery/*` endpoints at all. `packages/mcp/README.md` likewise.

## Checks

`pnpm lint`, `pnpm typecheck`, `pnpm test` (257 tests) all green locally.
